### PR TITLE
proxy: Implement prototype

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,9 +98,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup | Install packages
-        run: sudo apt-get install libssl-dev
-
       - name: Setup | Install toolchain
         run: |
           # 1.66 is the Minimum Supported Rust Version (MSRV) for imap-flow.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,8 +100,8 @@ jobs:
 
       - name: Setup | Install toolchain
         run: |
-          # 1.65 is the Minimum Supported Rust Version (MSRV) for imap-codec.
-          rustup toolchain install 1.65 --profile minimal
+          # 1.66 is the Minimum Supported Rust Version (MSRV) for imap-flow.
+          rustup toolchain install 1.66 --profile minimal
           rustup toolchain install nightly --profile minimal
 
       - name: Setup | Cache dependencies
@@ -113,8 +113,8 @@ jobs:
       - name: Check
         run: |
           cargo +nightly update -Z minimal-versions
-          cargo +1.65 check --workspace --all-targets --all-features
-          cargo +1.65 test --workspace --all-targets --all-features # TODO: exclude fuzz-targets
+          cargo +1.66 check --workspace --all-targets --all-features
+          cargo +1.66 test --workspace --all-targets --all-features # TODO: exclude fuzz-targets
         env:
           RUSTFLAGS: -Dwarnings
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,6 +98,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup | Install packages
+        run: sudo apt-get install libssl-dev
+
       - name: Setup | Install toolchain
         run: |
           # 1.66 is the Minimum Supported Rust Version (MSRV) for imap-flow.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,10 @@ tokio = { version = "1.32.0", features = ["io-util"] }
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }
+
+[workspace]
+resolver = "2"
+members = [
+  ".",
+  "proxy"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,5 @@ tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }
 [workspace]
 resolver = "2"
 members = [
-  ".",
   "proxy"
 ]

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "proxy"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.75"
+colored = "2.0.4"
+imap-codec = { version = "1.0.0", features = ["bounded-static", "quirk_crlf_relaxed"] }
+imap-flow = { path = ".." }
+native-tls = "0.2.11"
+serde = { version = "1.0.171", features = ["derive"] }
+thiserror = "1.0.49"
+tokio = { version = "1.28", features = ["full"] }
+tokio-rustls = "0.24.1"
+toml = "0.8.2"
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+webpki-roots = "0.24.0"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0.75"
 colored = "2.0.4"
 imap-codec = { version = "1.0.0", features = ["bounded-static", "quirk_crlf_relaxed"] }
 imap-flow = { path = ".." }
-native-tls = "0.2.11"
 serde = { version = "1.0.171", features = ["derive"] }
 thiserror = "1.0.49"
 tokio = { version = "1.28", features = ["full"] }

--- a/proxy/config.toml
+++ b/proxy/config.toml
@@ -1,0 +1,24 @@
+[[services]]
+name = "Testing"
+bind = { host = "127.0.0.1", port = 1143, security = "Insecure" }
+connect = { host = "127.0.0.1", port = 9143, security = "Insecure" }
+
+[[services]]
+name = "GMX"
+bind = { host = "127.0.0.1", port = 2143, security = "Insecure" }
+connect = { host = "imap.gmx.de", port = 993 }
+
+[[services]]
+name = "mailbox.org"
+bind = { host = "127.0.0.1", port = 3143, security = "Insecure" }
+connect = { host = "imap.mailbox.org", port = 993 }
+
+[[services]]
+name = "Zoho Mail"
+bind = { host = "127.0.0.1", port = 4143, security = "Insecure" }
+connect = { host = "imap.zoho.eu", port = 993 }
+
+[[services]]
+name = "iCloud"
+bind = { host = "127.0.0.1", port = 5143, security = "Insecure" }
+connect = { host = "imap.mail.me.com", port = 993 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use serde::Deserialize;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Config {
+    pub services: Vec<Service>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Service {
+    pub name: String,
+    pub bind: Addr,
+    pub connect: Addr,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Addr {
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub security: Security,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub enum Security {
+    #[default]
+    Tls,
+    Insecure,
+}
+
+impl Config {
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        Ok(toml::from_str(&std::fs::read_to_string(path)?)?)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Parse(#[from] toml::de::Error),
+}

--- a/proxy/src/main.rs
+++ b/proxy/src/main.rs
@@ -1,0 +1,84 @@
+mod config;
+mod proxy;
+mod util;
+
+use anyhow::{Context, Result};
+use config::{Config, Service};
+use proxy::{ClientAcceptedState, Proxy};
+use tokio::task::JoinSet;
+use tracing::{error, instrument, Instrument};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_target(false)
+        .with_file(false)
+        .with_line_number(false)
+        .without_time()
+        .init();
+
+    // Load config file
+    let config = {
+        let config_path = std::env::args().nth(1).unwrap_or("config.toml".to_string());
+
+        Config::load(&config_path)
+            .with_context(|| format!("Failed to load config from '{config_path}'"))?
+    };
+
+    // Start proxy services
+    let mut set = JoinSet::new();
+    for service in config.services {
+        set.spawn(handle_service(service));
+    }
+
+    // Terminate once all services has stopped
+    while let Some(res) = set.join_next().await {
+        if let Err(error) = res {
+            error!(?error, "Failed to join with service task");
+        }
+    }
+    Ok(())
+}
+
+#[instrument(name = "service", skip_all, fields(name = service.name))]
+async fn handle_service(service: Service) {
+    // Bind to port
+    let proxy = match Proxy::bind(service.clone()).await {
+        Ok(proxy) => proxy,
+        Err(error) => {
+            error!(?error, "Failed to start service");
+            return ();
+        }
+    };
+
+    loop {
+        // Wait for client
+        let proxy = match proxy.accept_client().await {
+            Ok(result) => result,
+            Err(error) => {
+                error!(?error, "Failed to accept client");
+                continue;
+            }
+        };
+
+        // Handle client
+        tokio::spawn(
+            async {
+                if let Err(error) = handle_client(proxy).await {
+                    error!(?error, "Connection finished unexpectedly");
+                }
+            }
+            .in_current_span(),
+        );
+    }
+}
+
+#[instrument(name = "client", skip_all, fields(addr = %proxy.client_addr()))]
+async fn handle_client(proxy: Proxy<ClientAcceptedState>) -> Result<()> {
+    let proxy = proxy.connect_to_server().await?;
+    proxy.start_conversion().await;
+    Ok(())
+}

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -1,0 +1,277 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use colored::Colorize;
+use imap_flow::{
+    client::{ClientFlow, ClientFlowError, ClientFlowEvent, ClientFlowOptions},
+    server::{ServerFlow, ServerFlowError, ServerFlowEvent, ServerFlowOptions},
+    stream::AnyStream,
+};
+use thiserror::Error;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::{
+    rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName},
+    TlsConnector,
+};
+use tracing::{error, info, trace};
+
+use crate::{
+    config::Service,
+    util::{self, ControlFlow},
+};
+
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+pub trait State: Send + 'static {}
+
+pub struct Proxy<S: State> {
+    service: Service,
+    state: S,
+}
+
+pub struct BoundState {
+    listener: TcpListener,
+}
+
+impl State for BoundState {}
+
+impl Proxy<BoundState> {
+    pub async fn bind(service: Service) -> Result<Self, ProxyError> {
+        // Accept arbitrary number of connections.
+        let bind_addr_port = format!("{}:{}", service.bind.host, service.bind.port);
+        let listener = TcpListener::bind(&bind_addr_port).await?;
+        info!(?bind_addr_port, "Bound to");
+
+        Ok(Self {
+            service,
+            state: BoundState { listener },
+        })
+    }
+
+    pub async fn accept_client(&self) -> Result<Proxy<ClientAcceptedState>, ProxyError> {
+        let (client_to_proxy, client_addr) = self.state.listener.accept().await?;
+        info!(?client_addr, "Accepted client");
+
+        Ok(Proxy {
+            service: self.service.clone(),
+            state: ClientAcceptedState {
+                client_addr,
+                client_to_proxy: AnyStream::new(client_to_proxy),
+            },
+        })
+    }
+}
+
+pub struct ClientAcceptedState {
+    client_addr: SocketAddr,
+    client_to_proxy: AnyStream,
+}
+
+impl State for ClientAcceptedState {}
+
+impl Proxy<ClientAcceptedState> {
+    pub fn client_addr(&self) -> SocketAddr {
+        self.state.client_addr
+    }
+
+    pub async fn connect_to_server(self) -> Result<Proxy<ConnectedState>, ProxyError> {
+        let server_addr = &self.service.connect.host;
+        let server_port = &self.service.connect.port;
+        let server_addr_port = format!("{server_addr}:{server_port}");
+
+        info!(?server_addr_port, "Connecting to server");
+        let proxy_to_server = match TcpStream::connect(&server_addr_port).await {
+            Ok(stream_to_server) => {
+                let mut root_cert_store = RootCertStore::empty();
+                #[allow(deprecated)] // TODO: Fix deprecation warning
+                root_cert_store.add_server_trust_anchors(
+                    webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+                        OwnedTrustAnchor::from_subject_spki_name_constraints(
+                            ta.subject,
+                            ta.spki,
+                            ta.name_constraints,
+                        )
+                    }),
+                );
+                let config = ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_root_certificates(root_cert_store)
+                    .with_no_client_auth();
+                let connector = TlsConnector::from(Arc::new(config));
+                let dnsname = ServerName::try_from(server_addr.as_str()).unwrap();
+
+                info!(?server_addr_port, "Starting TLS with server");
+                connector.connect(dnsname, stream_to_server).await.unwrap()
+            }
+            Err(err) => {
+                error!(%err, "Failed to connect to server");
+                return Err(err.into());
+            }
+        };
+        info!(?server_addr_port, "Connected to server");
+
+        Ok(Proxy {
+            service: self.service,
+            state: ConnectedState {
+                client_to_proxy: self.state.client_to_proxy,
+                proxy_to_server: AnyStream::new(proxy_to_server),
+            },
+        })
+    }
+}
+
+pub struct ConnectedState {
+    client_to_proxy: AnyStream,
+    proxy_to_server: AnyStream,
+}
+
+impl State for ConnectedState {}
+
+impl Proxy<ConnectedState> {
+    pub async fn start_conversion(self) {
+        let (mut proxy_to_server, mut greeting) = {
+            // TODO: Read options from config
+            let options = ClientFlowOptions { crlf_relaxed: true };
+
+            let result = ClientFlow::receive_greeting(self.state.proxy_to_server, options).await;
+
+            match result {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(?error, "Failed to receive greeting");
+                    return;
+                }
+            }
+        };
+        trace!(greeting=%format!("{:?}", greeting).blue(), role = "s2p", "<--| Received greeting");
+
+        util::filter_capabilities_in_greeting(&mut greeting);
+
+        let mut client_to_proxy = {
+            // TODO: Read options from config
+            let options = ServerFlowOptions {
+                crlf_relaxed: true,
+                max_literal_size: u32::MAX,
+            };
+
+            let result =
+                ServerFlow::send_greeting(self.state.client_to_proxy, options, greeting).await;
+
+            match result {
+                Ok(value) => value,
+                Err(error) => {
+                    error!(?error, "Failed to forward greeting");
+                    return;
+                }
+            }
+        };
+        trace!(role = "p2c", "<--- Forwarded greeting");
+
+        loop {
+            let control_flow = tokio::select! {
+                event = client_to_proxy.progress() => {
+                    handle_client_event(event, &mut proxy_to_server)
+                }
+                event = proxy_to_server.progress() => {
+                    handle_server_event(event, &mut client_to_proxy)
+                }
+            };
+
+            if let ControlFlow::Abort = control_flow {
+                break;
+            }
+        }
+    }
+}
+
+fn handle_client_event(
+    error: Result<ServerFlowEvent, ServerFlowError>,
+    proxy_to_server: &mut ClientFlow,
+) -> ControlFlow {
+    let event = match error {
+        Ok(event) => event,
+        Err(
+            ref error @ (ServerFlowError::ExpectedCrlfGotLf {
+                ref discarded_bytes,
+            }
+            | ServerFlowError::MalformedMessage {
+                ref discarded_bytes,
+            }
+            | ServerFlowError::LiteralTooLong {
+                ref discarded_bytes,
+            }),
+        ) => {
+            info!(role = "c2p", %error, ?discarded_bytes, "Discard client message");
+            return ControlFlow::Continue;
+        }
+        Err(ServerFlowError::Io(error)) => {
+            info!(role = "c2p", %error, "Connection terminated");
+            return ControlFlow::Abort;
+        }
+    };
+
+    match event {
+        ServerFlowEvent::ResponseSent { handle: _handle } => {
+            // TODO: log handle
+            trace!(role = "p2c", "<--- Forwarded response");
+        }
+        ServerFlowEvent::CommandReceived { command } => {
+            trace!(command=%format!("{:?}", command).red(), role = "c2p", "|--> Received command");
+            let _handle = proxy_to_server.enqueue_command(command);
+            // TODO: log handle
+        }
+    }
+
+    ControlFlow::Continue
+}
+
+fn handle_server_event(
+    event: Result<ClientFlowEvent, ClientFlowError>,
+    client_to_proxy: &mut ServerFlow,
+) -> ControlFlow {
+    let event = match event {
+        Ok(event) => event,
+        Err(
+            ref error @ (ClientFlowError::ExpectedCrlfGotLf {
+                ref discarded_bytes,
+            }
+            | ClientFlowError::MalformedMessage {
+                ref discarded_bytes,
+            }),
+        ) => {
+            info!(role = "c2p", %error, ?discarded_bytes, "Discard server message");
+            return ControlFlow::Continue;
+        }
+        Err(ClientFlowError::Io(error)) => {
+            info!(role = "s2p", %error, "Connection terminated");
+            return ControlFlow::Abort;
+        }
+    };
+
+    match event {
+        ClientFlowEvent::CommandSent {
+            tag,
+            handle: _handle,
+        } => {
+            // TODO: log handle
+            trace!(role = "p2s", ?tag, "---> Forwarded command");
+        }
+        ClientFlowEvent::DataReceived { mut data } => {
+            trace!(data=%format!("{:?}", data).blue(), role = "s2p", "<--| Received data");
+            util::filter_capabilities_in_data(&mut data);
+            let _handle = client_to_proxy.enqueue_data(data);
+            // TODO: log handle
+        }
+        ClientFlowEvent::StatusReceived { mut status } => {
+            trace!(response=%format!("{:?}", status).blue(), role = "s2p", "<--| Received status");
+            util::filter_capabilities_in_status(&mut status);
+            let _handle = client_to_proxy.enqueue_status(status);
+            // TODO: log handle
+        }
+    }
+
+    ControlFlow::Continue
+}

--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -1,0 +1,88 @@
+use imap_codec::imap_types::{
+    core::NonEmptyVec,
+    response::{Capability, Code, Data, Greeting, Status},
+};
+use tracing::warn;
+
+pub enum ControlFlow {
+    Continue,
+    Abort,
+}
+
+// Remove unsupported capabilities in a greetings `Code::Capability`.
+pub fn filter_capabilities_in_greeting(greeting: &mut Greeting) {
+    if let Some(Code::Capability(capabilities)) = &mut greeting.code {
+        let filtered = filter_capabilities(capabilities.clone());
+
+        if *capabilities != filtered {
+            warn!(
+                before=?capabilities,
+                after=?filtered.clone(),
+                "Filtered capabilities in greeting",
+            );
+            *capabilities = filtered;
+        }
+    }
+}
+
+// Remove unsupported capabilities in a `Data::Capability`.
+pub fn filter_capabilities_in_data(data: &mut Data) {
+    if let Data::Capability(capabilities) = data {
+        let filtered = filter_capabilities(capabilities.clone());
+
+        if *capabilities != filtered {
+            warn!(
+                before=?capabilities,
+                after=?filtered,
+                "Filtered capabilities in data",
+            );
+            *capabilities = filtered;
+        }
+    }
+}
+
+// Remove unsupported capabilities in a status' `Code::Capability`.
+pub fn filter_capabilities_in_status(status: &mut Status) {
+    if let Status::Ok {
+        code: Some(Code::Capability(capabilities)),
+        ..
+    }
+    | Status::No {
+        code: Some(Code::Capability(capabilities)),
+        ..
+    }
+    | Status::Bad {
+        code: Some(Code::Capability(capabilities)),
+        ..
+    }
+    | Status::Bye {
+        code: Some(Code::Capability(capabilities)),
+        ..
+    } = status
+    {
+        let filtered = filter_capabilities(capabilities.clone());
+
+        if *capabilities != filtered {
+            warn!(
+                before=?capabilities,
+                after=?filtered,
+                "Filtered capabilities in status",
+            );
+            *capabilities = filtered;
+        }
+    }
+}
+
+// Remove unsupported capabilities in a capability list.
+fn filter_capabilities(capabilities: NonEmptyVec<Capability>) -> NonEmptyVec<Capability> {
+    let filtered: Vec<_> = capabilities
+        .into_iter()
+        // TODO: We want to support other AUTH mechanisms, too. AUTH=PLAIN at least.
+        //       However, for this to work, the proxy needs to learn how to handle
+        //       IMAP authentication flows. This *should* be the last remaining
+        //       difficulty we (probably) want to solve for basic IMAP interop.
+        .filter(|capability| matches!(capability, Capability::Imap4Rev1))
+        .collect();
+
+    NonEmptyVec::try_from(filtered).unwrap_or(NonEmptyVec::from(Capability::Imap4Rev1))
+}


### PR DESCRIPTION
First prototype for an IMAP proxy.

It can be run with:

```sh
cd proxy
RUST_LOG=proxy=trace cargo run
```

There is a default config file located at `proxy/config.toml`. It contains ports that can be used to connect with a local email client.

The change set contains some TODOs. We need to create issues for them after merging this PR.

Closes #13