### PR TITLE
Refactor `imap_flow::stream`

### DIFF
--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -4,7 +4,7 @@ use colored::Colorize;
 use imap_flow::{
     client::{ClientFlow, ClientFlowError, ClientFlowEvent, ClientFlowOptions},
     server::{ServerFlow, ServerFlowError, ServerFlowEvent, ServerFlowOptions},
-    stream::AnyStream,
+    stream::Stream,
 };
 use thiserror::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -59,7 +59,7 @@ impl Proxy<BoundState> {
             service: self.service.clone(),
             state: ClientAcceptedState {
                 client_addr,
-                client_to_proxy: AnyStream::new(client_to_proxy),
+                client_to_proxy: Stream::new(client_to_proxy),
             },
         })
     }
@@ -67,7 +67,7 @@ impl Proxy<BoundState> {
 
 pub struct ClientAcceptedState {
     client_addr: SocketAddr,
-    client_to_proxy: AnyStream,
+    client_to_proxy: Stream,
 }
 
 impl State for ClientAcceptedState {}
@@ -117,15 +117,15 @@ impl Proxy<ClientAcceptedState> {
             service: self.service,
             state: ConnectedState {
                 client_to_proxy: self.state.client_to_proxy,
-                proxy_to_server: AnyStream::new(proxy_to_server),
+                proxy_to_server: Stream::new(proxy_to_server),
             },
         })
     }
 }
 
 pub struct ConnectedState {
-    client_to_proxy: AnyStream,
-    proxy_to_server: AnyStream,
+    client_to_proxy: Stream,
+    proxy_to_server: Stream,
 }
 
 impl State for ConnectedState {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use thiserror::Error;
 use crate::{
     receive::{ReceiveEvent, ReceiveState},
     send::SendCommandState,
-    stream::AnyStream,
+    stream::Stream,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -32,7 +32,7 @@ impl Default for ClientFlowOptions {
 }
 
 pub struct ClientFlow {
-    stream: AnyStream,
+    stream: Stream,
 
     next_command_handle: ClientFlowCommandHandle,
     send_command_state: SendCommandState<(Tag<'static>, ClientFlowCommandHandle)>,
@@ -41,7 +41,7 @@ pub struct ClientFlow {
 
 impl ClientFlow {
     pub async fn receive_greeting(
-        mut stream: AnyStream,
+        mut stream: Stream,
         options: ClientFlowOptions,
     ) -> Result<(Self, Greeting<'static>), ClientFlowError> {
         // Receive greeting
@@ -79,6 +79,14 @@ impl ClientFlow {
         };
 
         Ok((client_flow, greeting))
+    }
+
+    pub fn stream(&self) -> &Stream {
+        &self.stream
+    }
+
+    pub fn stream_mut(&mut self) -> &mut Stream {
+        &mut self.stream
     }
 
     pub fn enqueue_command(&mut self, command: Command<'_>) -> ClientFlowCommandHandle {

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,7 +12,7 @@ use thiserror::Error;
 use crate::{
     receive::{ReceiveEvent, ReceiveState},
     send::SendResponseState,
-    stream::AnyStream,
+    stream::Stream,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -33,7 +33,7 @@ impl Default for ServerFlowOptions {
 }
 
 pub struct ServerFlow {
-    stream: AnyStream,
+    stream: Stream,
     max_literal_size: u32,
 
     next_response_handle: ServerFlowResponseHandle,
@@ -43,7 +43,7 @@ pub struct ServerFlow {
 
 impl ServerFlow {
     pub async fn send_greeting(
-        mut stream: AnyStream,
+        mut stream: Stream,
         options: ServerFlowOptions,
         greeting: Greeting<'_>,
     ) -> Result<Self, ServerFlowError> {
@@ -69,6 +69,14 @@ impl ServerFlow {
         };
 
         Ok(server_flow)
+    }
+
+    pub fn stream(&self) -> &Stream {
+        &self.stream
+    }
+
+    pub fn stream_mut(&mut self) -> &mut Stream {
+        &mut self.stream
     }
 
     pub fn enqueue_data(&mut self, data: Data<'_>) -> ServerFlowResponseHandle {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -2,7 +2,7 @@ use imap_codec::imap_types::response::Greeting;
 use imap_flow::{
     client::{ClientFlow, ClientFlowOptions},
     server::{ServerFlow, ServerFlowOptions},
-    stream::AnyStream,
+    stream::Stream,
 };
 use tokio::net::{TcpListener, TcpStream};
 
@@ -21,7 +21,7 @@ async fn self_test() {
             let (stream, _) = listener.accept().await.unwrap();
 
             ServerFlow::send_greeting(
-                AnyStream::new(stream),
+                Stream::new(stream),
                 ServerFlowOptions::default(),
                 greeting.clone(),
             )
@@ -34,7 +34,7 @@ async fn self_test() {
 
     let (_, received_greeting) = {
         let stream = TcpStream::connect(("127.0.0.1", port)).await.unwrap();
-        ClientFlow::receive_greeting(AnyStream::new(stream), ClientFlowOptions::default())
+        ClientFlow::receive_greeting(Stream::new(stream), ClientFlowOptions::default())
             .await
             .unwrap()
     };


### PR DESCRIPTION
Previously there were two public types in `imap_flow::stream`:

- The trait `Stream`: This trait existed only for technical reasons. The user might think that they should implement it, which is wrong.
- The struct `AnyStream`. Handles the boxing, the pinning and the dynamic dispatch. This is the type that the user should interact with.

The new API looks like this:
- `imap_flow::stream` has now only a single type, the struct `Stream`
  - It can be constructed with `_::new`
  - It provides access to the underlying `AsyncRead` via `_::read` and `_::read_mut`
  - It provides access to the underlying `AsyncWrite` via `_:::write` and `_::write_mut`
- `ClientFlow` and `ServerFlow` provide access to the underlying `Stream` via `_::stream` and `_::stream_mut`

Closes #18