### PR TITLE
docs: Provide simple client and server examples

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,0 +1,43 @@
+use imap_codec::imap_types::{
+    command::{Command, CommandBody},
+    core::Tag,
+};
+use imap_flow::{
+    client::{ClientFlow, ClientFlowEvent, ClientFlowOptions},
+    stream::AnyStream,
+};
+use tokio::net::TcpStream;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+
+    let (mut client, greeting) =
+        ClientFlow::receive_greeting(AnyStream::new(stream), ClientFlowOptions::default())
+            .await
+            .unwrap();
+    println!("received greeting: {greeting:?}");
+
+    let handle = client.enqueue_command(Command {
+        tag: Tag::try_from("A1").unwrap(),
+        body: CommandBody::Noop,
+    });
+
+    loop {
+        match client.progress().await.unwrap() {
+            ClientFlowEvent::CommandSent {
+                tag,
+                handle: got_handle,
+            } => {
+                println!("command sent: {tag:?}, {handle:?}");
+                assert_eq!(handle, got_handle);
+            }
+            ClientFlowEvent::DataReceived { data } => {
+                println!("data received: {data:?}");
+            }
+            ClientFlowEvent::StatusReceived { status } => {
+                println!("status received: {status:?}");
+            }
+        }
+    }
+}

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,42 @@
+use imap_codec::imap_types::response::{Greeting, Status};
+use imap_flow::{
+    server::{ServerFlow, ServerFlowEvent, ServerFlowOptions},
+    stream::AnyStream,
+};
+use tokio::net::TcpListener;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let stream = {
+        let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+
+        let (stream, _) = listener.accept().await.unwrap();
+
+        stream
+    };
+
+    let mut server = ServerFlow::send_greeting(
+        AnyStream::new(stream),
+        ServerFlowOptions::default(),
+        Greeting::ok(None, "Hello, World!").unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let mut handle = None;
+
+    loop {
+        match server.progress().await.unwrap() {
+            ServerFlowEvent::CommandReceived { command } => {
+                println!("command received: {command:?}");
+                handle = Some(
+                    server.enqueue_status(Status::no(Some(command.tag), None, "...").unwrap()),
+                );
+            }
+            ServerFlowEvent::ResponseSent { handle: got_handle } => {
+                println!("response sent: {handle:?}");
+                assert_eq!(handle, Some(got_handle));
+            }
+        }
+    }
+}


### PR DESCRIPTION
I initially wanted to copy the examples from `imap` and `async_imap`. However, in order to do so, we already need a higher-level API. It doesn't make a lot of sense to implement these examples now. So, for now, I'll use the examples as playground for just the things we want to abstract over in imap-flow, i.e., literal handling, authentication, and idle, and be careful to not do too much already.