### PR TITLE
feat: Improve handle handling

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -26,10 +26,18 @@ async fn main() {
     loop {
         match client.progress().await.unwrap() {
             ClientFlowEvent::CommandSent {
-                tag,
                 handle: got_handle,
+                tag,
             } => {
-                println!("command sent: {tag:?}, {handle:?}");
+                println!("command sent: {got_handle:?}, {tag:?}");
+                assert_eq!(handle, got_handle);
+            }
+            ClientFlowEvent::CommandRejected {
+                handle: got_handle,
+                tag,
+                status,
+            } => {
+                println!("command rejected: {got_handle:?}, {tag:?}, {status:?}");
                 assert_eq!(handle, got_handle);
             }
             ClientFlowEvent::DataReceived { data } => {

--- a/src/send.rs
+++ b/src/send.rs
@@ -42,9 +42,9 @@ impl<K> SendCommandState<K> {
         self.send_progress.as_ref().map(|x| &x.key)
     }
 
-    pub fn abort_command(&mut self) {
-        self.send_progress = None;
+    pub fn abort_command(&mut self) -> Option<K> {
         self.write_buffer.clear();
+        self.send_progress.take().map(|x| x.key)
     }
 
     pub fn continue_command(&mut self) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -84,6 +84,11 @@ impl ServerFlow {
         Ok(server_flow)
     }
 
+    /// Enqueues the [`Data`] response for being sent to the client.
+    ///
+    /// The response is not sent immediately but during one of the next calls of
+    /// [`ServerFlow::progress`]. All responses are sent in the same order they have been
+    /// enqueued.
     pub fn enqueue_data(&mut self, data: Data<'_>) -> ServerFlowResponseHandle {
         let handle = self.next_response_handle();
         self.send_response_state
@@ -91,6 +96,11 @@ impl ServerFlow {
         handle
     }
 
+    /// Enqueues the [`Status`] response for being sent to the client.
+    ///
+    /// The response is not sent immediately but during one of the next calls of
+    /// [`ServerFlow::progress`]. All responses are sent in the same order they have been
+    /// enqueued.
     pub fn enqueue_status(&mut self, status: Status<'_>) -> ServerFlowResponseHandle {
         let handle = self.next_response_handle();
         self.send_response_state
@@ -177,13 +187,25 @@ impl ServerFlow {
     }
 }
 
+/// A handle for an enqueued [`Response`].
+///
+/// This handle can be used to track the sending progress. After a [`Response`] was enqueued via
+/// [`ServerFlow::enqueue_data`] or [`ServerFlow::enqueue_status`] it is in the process of being
+/// sent until [`ServerFlow::progress`] returns a [`ServerFlowEvent::ResponseSent`] with the
+/// corresponding handle.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct ServerFlowResponseHandle(u64);
 
 #[derive(Debug)]
 pub enum ServerFlowEvent {
-    ResponseSent { handle: ServerFlowResponseHandle },
-    CommandReceived { command: Command<'static> },
+    /// The enqueued [`Response`] was sent successfully.
+    ResponseSent {
+        /// The handle of the enqueued [`Response`].
+        handle: ServerFlowResponseHandle,
+    },
+    CommandReceived {
+        command: Command<'static>,
+    },
 }
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Before this PR:

- If `ClientFlow` receives a `Status::Bad` with the matching tag then the current `Command` will be aborted
- All received `Status` (including the one mentioned before) will be emitted via `ClientFlowEvent::StatusReceived`
  - `ClientFlowEvent::StatusReceived` does not contain the `ClientFlowCommandHandle`
  - The user of `ClientFlow` must do complicated logic in order to detect the abortion of the `Command`

After this PR:

- If `ClientFlow` receives a `Status::Bad` with the matching tag then the current `Command` will be aborted and `ClientFlowEvent::CommandRejected` will be emitted
  -  `ClientFlowEvent::CommandRejected` contains the `ClientFlowCommandHandle`
- All other received `Status` will be emitted via `ClientFlowEvent::StatusReceived`

Why this might be a good idea:

- Sending the `Command` (and handling literals) is the responsibility of `imap-flow`
- In order to do so `ClientFlow` needs to handle `Status::Bad` in some cases
- By introducing a new variant for `ClientFlowEvent` it's now clear that:
  - in case of `ClientFlowEvent::CommandRejected` the `Status` was already handled by `ClientFlow`
  - in case of `ClientFlowEvent::StatusReceived` the `Status` needs to be handled by the user of `ClientFlow`
    -  the user of `ClientFlow` can more easily detect an unexpected `Status` and log it
- The user of `ClientFlow` can simply match on `ClientFlowEvent::CommandSent` or `ClientFlowEvent::CommandRejected` to detect when the sending process of the `Command` is finished

I also improved the documentation for both `ClientFlowCommandHandle` and `ServerFlowResponseHandle`.

Closes #45