### PR TITLE
feat: First draft of `tasks`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,8 @@ resolver = "2"
 members = [
     "proxy",
     "tag-generator",
+    "tasks",
 ]
+
+[patch.crates-io]
+imap-types = { git = "https://github.com/duesee/imap-codec" }

--- a/deny.toml
+++ b/deny.toml
@@ -2,5 +2,9 @@
 unknown-registry = "deny"
 unknown-git      = "deny"
 
+allow-git = [
+    "https://github.com/duesee/imap-codec",
+]
+
 [licenses]
 allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016" ]

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "tasks"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+imap-codec = "1.0.0"
+imap-flow = { path = ".." }
+tag-generator = { path = "../tag-generator" }
+thiserror = "1.0.50"
+tokio = { version = "1.32.0", features = ["full"] }

--- a/tasks/examples/client.rs
+++ b/tasks/examples/client.rs
@@ -1,0 +1,50 @@
+use imap_codec::imap_types::response::{Response, Status};
+use imap_flow::{
+    client::{ClientFlow, ClientFlowOptions},
+    stream::AnyStream,
+};
+use tasks::{
+    tasks::{CapabilityTask, LogoutTask},
+    Scheduler, SchedulerEvent,
+};
+use tokio::net::TcpStream;
+
+#[tokio::main]
+async fn main() {
+    let mut scheduler = {
+        let (flow, _) = {
+            let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+
+            ClientFlow::receive_greeting(AnyStream::new(stream), ClientFlowOptions::default())
+                .await
+                .unwrap()
+        };
+
+        Scheduler::new(flow)
+    };
+
+    let handle1 = scheduler.enqueue_task(CapabilityTask::default());
+    let handle2 = scheduler.enqueue_task(LogoutTask::default());
+
+    loop {
+        match scheduler.progress().await.unwrap() {
+            SchedulerEvent::TaskFinished(mut token) => {
+                if let Some(capability) = handle1.resolve(&mut token) {
+                    println!("handle1: {capability:?}");
+                }
+
+                if let Some(logout) = handle2.resolve(&mut token) {
+                    println!("handle2: {logout:?}");
+                    break;
+                }
+            }
+            SchedulerEvent::Unsolicited(unsolicited) => {
+                println!("unsolicited: {unsolicited:?}");
+
+                if let Response::Status(Status::Bye { .. }) = unsolicited {
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/tasks/src/lib.rs
+++ b/tasks/src/lib.rs
@@ -1,0 +1,332 @@
+use std::{
+    any::Any,
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+    marker::PhantomData,
+};
+
+use imap_codec::imap_types::{
+    command::{Command, CommandBody},
+    core::Tag,
+    response::{Bye, Data, Response, Status, StatusBody, StatusV2, Tagged},
+};
+use imap_flow::client::{ClientFlow, ClientFlowCommandHandle, ClientFlowError, ClientFlowEvent};
+use tag_generator::TagGenerator;
+use thiserror::Error;
+
+pub mod tasks;
+
+/// Tells how a specific IMAP [`Command`] is processed.
+///
+/// Most `process_` trait methods consume interesting responses (returning `None`),
+/// and move out uninteresting responses (returning `Some(...)`).
+///
+/// If no active task is interested in a given response, we call this response "unsolicited".
+pub trait Task: 'static {
+    /// Output of the task.
+    ///
+    /// Returned in [`Self::process_tagged`].
+    type Output;
+
+    /// Returns the [`CommandBody`] to issue for this task.
+    ///
+    /// Note: The [`Scheduler`] will tag the [`CommandBody`] creating a complete [`Command`].
+    fn command_body(&self) -> CommandBody<'static>;
+
+    /// Process data response.
+    fn process_data(&mut self, data: Data<'static>) -> Option<Data<'static>> {
+        // Default: Don't process server data
+        Some(data)
+    }
+
+    /// Process an untagged response.
+    fn process_untagged(
+        &mut self,
+        status_body: StatusBody<'static>,
+    ) -> Option<StatusBody<'static>> {
+        // Default: Don't process untagged status
+        Some(status_body)
+    }
+
+    /// Process bye response.
+    fn process_bye(&mut self, bye: Bye<'static>) -> Option<Bye<'static>> {
+        // Default: Don't process bye
+        Some(bye)
+    }
+
+    /// Process command completion result response.
+    ///
+    /// The [`Scheduler`] already chooses the corresponding response by tag.
+    fn process_tagged(self, status_body: StatusBody<'static>) -> Self::Output;
+}
+
+/// Scheduler managing enqueued tasks and routing incoming responses to active tasks.
+pub struct Scheduler {
+    flow: ClientFlow,
+    waiting_tasks: HashMap<ClientFlowCommandHandle, Box<dyn TaskAny>>,
+    active_tasks: HashMap<ClientFlowCommandHandle, (Tag<'static>, Box<dyn TaskAny>)>,
+    tag_generator: TagGenerator,
+}
+
+impl Scheduler {
+    /// Create a new scheduler.
+    pub fn new(flow: ClientFlow) -> Self {
+        Self {
+            flow,
+            waiting_tasks: Default::default(),
+            active_tasks: Default::default(),
+            tag_generator: TagGenerator::new(),
+        }
+    }
+
+    /// Enqueue a [`Task`].
+    pub fn enqueue_task<T>(&mut self, task: T) -> TaskHandle<T>
+    where
+        T: Task,
+    {
+        let cmd = {
+            let tag = self.tag_generator.generate();
+            let body = task.command_body();
+
+            Command { tag, body }
+        };
+
+        let handle = self.flow.enqueue_command(cmd);
+
+        let replaced = self.waiting_tasks.insert(handle, Box::new(task));
+        assert!(replaced.is_none());
+
+        TaskHandle::new(handle)
+    }
+
+    /// Progress the connection returning the next event.
+    pub async fn progress(&mut self) -> Result<SchedulerEvent, SchedulerError> {
+        loop {
+            let event = self.flow.progress().await?;
+
+            match event {
+                ClientFlowEvent::CommandSent { tag, handle } => {
+                    // This `unwrap` can't fail because `waiting_tasks` contains all unsent `Commands`.
+                    let entry = self.waiting_tasks.remove(&handle).unwrap();
+                    self.active_tasks.insert(handle, (tag, entry));
+                }
+                ClientFlowEvent::CommandRejected { handle, status, .. } => {
+                    let body = match StatusV2::from(status) {
+                        StatusV2::Tagged(Tagged { body, .. }) => body,
+                        _ => unreachable!(),
+                    };
+
+                    // This `unwrap` can't fail because `active_tasks` contains all in-progress `Commands`.
+                    let (_, task) = self.active_tasks.remove(&handle).unwrap();
+
+                    let output = Some(task.process_tagged(body));
+
+                    return Ok(SchedulerEvent::TaskFinished(TaskToken { handle, output }));
+                }
+                ClientFlowEvent::DataReceived { data } => {
+                    if let Some(data) = trickle_down(data, self.active_tasks_mut(), |task, data| {
+                        task.process_data(data)
+                    }) {
+                        return Ok(SchedulerEvent::Unsolicited(Response::Data(data)));
+                    }
+                }
+                ClientFlowEvent::StatusReceived { status } => match StatusV2::from(status) {
+                    StatusV2::Untagged(body) => {
+                        if let Some(body) =
+                            trickle_down(body, self.active_tasks_mut(), |task, body| {
+                                task.process_untagged(body)
+                            })
+                        {
+                            return Ok(SchedulerEvent::Unsolicited(Response::Status(
+                                Status::from(StatusV2::Untagged(body)),
+                            )));
+                        }
+                    }
+                    StatusV2::Bye(bye) => {
+                        if let Some(bye) =
+                            trickle_down(bye, self.active_tasks_mut(), |task, bye| {
+                                task.process_bye(bye)
+                            })
+                        {
+                            return Ok(SchedulerEvent::Unsolicited(Response::Status(
+                                Status::from(StatusV2::Bye(bye)),
+                            )));
+                        }
+                    }
+                    StatusV2::Tagged(Tagged { tag, body }) => {
+                        let handle = {
+                            if let Some((handle, _)) =
+                                self.active_tasks.iter().find(|(_, (tag_, _))| tag == *tag_)
+                            {
+                                *handle
+                            } else {
+                                return Err(SchedulerError::UnexpectedTaggedResponse(Tagged {
+                                    tag,
+                                    body,
+                                }));
+                            }
+                        };
+
+                        let (_, task) = self.active_tasks.remove(&handle).unwrap();
+
+                        let output = Some(task.process_tagged(body));
+
+                        return Ok(SchedulerEvent::TaskFinished(TaskToken { handle, output }));
+                    }
+                },
+            }
+        }
+    }
+
+    fn active_tasks_mut(&mut self) -> impl Iterator<Item = &mut Box<dyn TaskAny>> {
+        self.active_tasks.values_mut().map(|(_, task)| task)
+    }
+}
+
+#[derive(Debug)]
+pub enum SchedulerEvent {
+    TaskFinished(TaskToken),
+    Unsolicited(Response<'static>),
+}
+
+#[derive(Debug, Error)]
+pub enum SchedulerError {
+    /// Flow error.
+    #[error("flow error")]
+    Flow(#[from] ClientFlowError),
+    /// Unexpected tag in command completion result.
+    ///
+    /// The scheduler received a tag that cannot be matched to an active command.
+    /// This could be due to a severe implementation error in the scheduler,
+    /// the server, or anything in-between, really.
+    ///
+    /// It's better to halt the execution to avoid damage.
+    #[error("unexpected tag in command completion result")]
+    UnexpectedTaggedResponse(Tagged<'static>),
+}
+
+#[derive(Eq)]
+pub struct TaskHandle<T: Task> {
+    handle: ClientFlowCommandHandle,
+    _t: PhantomData<T>,
+}
+
+impl<T: Task> Debug for TaskHandle<T> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        f.debug_struct("TaskHandle")
+            .field("handle", &self.handle)
+            .finish()
+    }
+}
+
+impl<T: Task> Clone for TaskHandle<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T: Task> Copy for TaskHandle<T> {}
+
+impl<T: Task> PartialEq for TaskHandle<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.handle == other.handle
+    }
+}
+
+impl<T: Task> TaskHandle<T> {
+    fn new(handle: ClientFlowCommandHandle) -> Self {
+        Self {
+            handle,
+            _t: Default::default(),
+        }
+    }
+
+    /// Try resolving the task invalidating the token.
+    ///
+    /// The token is invalidated iff the return value is `Some`.
+    pub fn resolve(&self, token: &mut TaskToken) -> Option<T::Output> {
+        if token.handle != self.handle {
+            return None;
+        }
+
+        let output = token.output.take()?;
+        let output = output.downcast::<T::Output>().unwrap();
+
+        Some(*output)
+    }
+}
+
+#[derive(Debug)]
+pub struct TaskToken {
+    // TODO(#53): Bind this token to a `Scheduler` instance.
+    //            Make sure invariants can't be bypassed by creating a second scheduler.
+    handle: ClientFlowCommandHandle,
+    output: Option<Box<dyn Any>>,
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Move `trickle` from consumer to consumer until the first consumer doesn't hand it back.
+///
+/// If none of the consumers is interested in `trickle`, give it back.
+fn trickle_down<T, F, I>(trickle: T, consumers: I, f: F) -> Option<T>
+where
+    I: Iterator,
+    F: Fn(&mut I::Item, T) -> Option<T>,
+{
+    let mut trickle = Some(trickle);
+
+    for mut consumer in consumers {
+        if let Some(trickle_) = trickle {
+            trickle = f(&mut consumer, trickle_);
+
+            if trickle.is_none() {
+                break;
+            }
+        }
+    }
+
+    trickle
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Helper trait that ...
+///
+/// * doesn't have an associated type and uses [`Any`] in [`Self::process_tagged`]
+/// * is an object-safe "subset" of [`Task`]
+trait TaskAny {
+    fn process_data(&mut self, data: Data<'static>) -> Option<Data<'static>>;
+
+    fn process_untagged(&mut self, status_body: StatusBody<'static>)
+        -> Option<StatusBody<'static>>;
+
+    fn process_bye(&mut self, bye: Bye<'static>) -> Option<Bye<'static>>;
+
+    fn process_tagged(self: Box<Self>, status_body: StatusBody<'static>) -> Box<dyn Any>;
+}
+
+impl<T> TaskAny for T
+where
+    T: Task,
+{
+    fn process_data(&mut self, data: Data<'static>) -> Option<Data<'static>> {
+        T::process_data(self, data)
+    }
+
+    fn process_untagged(
+        &mut self,
+        status_body: StatusBody<'static>,
+    ) -> Option<StatusBody<'static>> {
+        T::process_untagged(self, status_body)
+    }
+
+    fn process_bye(&mut self, bye: Bye<'static>) -> Option<Bye<'static>> {
+        T::process_bye(self, bye)
+    }
+
+    /// Returns [`Any`] instead of [`Task::Output`].
+    fn process_tagged(self: Box<Self>, status_body: StatusBody<'static>) -> Box<dyn Any> {
+        Box::new(T::process_tagged(*self, status_body))
+    }
+}

--- a/tasks/src/tasks.rs
+++ b/tasks/src/tasks.rs
@@ -1,0 +1,75 @@
+//! Collection of common IMAP tasks.
+//!
+//! The tasks here correspond to the invocation (and processing) of a single command.
+
+use imap_codec::imap_types::{
+    command::CommandBody,
+    core::NonEmptyVec,
+    response::{Bye, Capability, Data, StatusBody, StatusKind},
+};
+
+use crate::Task;
+
+#[derive(Default)]
+pub struct CapabilityTask {
+    /// We use this as scratch space.
+    capabilities: Option<NonEmptyVec<Capability<'static>>>,
+}
+
+impl Task for CapabilityTask {
+    type Output = Result<NonEmptyVec<Capability<'static>>, &'static str>;
+
+    fn command_body(&self) -> CommandBody<'static> {
+        CommandBody::Capability
+    }
+
+    fn process_data(&mut self, data: Data<'static>) -> Option<Data<'static>> {
+        match data {
+            Data::Capability(capabilities) => {
+                self.capabilities = Some(capabilities);
+                None
+            }
+            unknown => Some(unknown),
+        }
+    }
+
+    fn process_tagged(self, status_body: StatusBody<'static>) -> Self::Output {
+        match status_body.kind {
+            StatusKind::Ok => match self.capabilities {
+                Some(capabilities) => Ok(capabilities),
+                None => Err("missing REQUIRED untagged CAPABILITY"),
+            },
+            StatusKind::No => Err("unexpected NO result"),
+            StatusKind::Bad => Err("command unknown or arguments invalid"),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct LogoutTask {
+    got_bye: bool,
+}
+
+impl Task for LogoutTask {
+    type Output = Result<(), &'static str>;
+
+    fn command_body(&self) -> CommandBody<'static> {
+        CommandBody::Logout
+    }
+
+    fn process_bye(&mut self, _: Bye<'static>) -> Option<Bye<'static>> {
+        self.got_bye = true;
+        None
+    }
+
+    fn process_tagged(self, status_body: StatusBody<'static>) -> Self::Output {
+        match status_body.kind {
+            StatusKind::Ok => match self.got_bye {
+                true => Ok(()),
+                false => Err("missing REQUIRED untagged BYE"),
+            },
+            StatusKind::No => Err("unexpected NO result"),
+            StatusKind::Bad => Err("command unknown or arguments invalid"),
+        }
+    }
+}


### PR DESCRIPTION
This is the current state of the `tasks` crate. I already like how working with it feels, but I am relatively sure we will want to change a few things as we go.

The next thing I would like to do is to port the "CLI demo" -- the thing that fetches all status data items from a server -- from the `duesee_cli` branch to `tasks` and fix everything on the way.

There are some open questions regarding error handling (that we probably should discuss in person), an `unwrap`, and a few missed opportunities for better code.

I feel that we can still be more liberal with anything that is not `imap-flow` for now. Thus, I'm primarily making this PR to have something usable online. What do you think?

By the way, I kept all commits in case they're helpful, but we probably should squash to a single commit listing us both as authors.