### PR TITLE
feat: Implement AUTHENTICATE flow

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,8 +1,11 @@
 use imap_codec::imap_types::{
     command::{Command, CommandBody},
     core::Tag,
+    response::Status,
+    secret::Secret,
 };
 use imap_flow::{
+    auth::Authenticate,
     client::{ClientFlow, ClientFlowEvent, ClientFlowOptions},
     stream::AnyStream,
 };
@@ -18,9 +21,10 @@ async fn main() {
             .unwrap();
     println!("received greeting: {greeting:?}");
 
-    let handle = client.enqueue_command(Command {
+    // TODO: Forbid Command::Authenticate.
+    let handle1 = client.enqueue_command(Command {
         tag: Tag::try_from("A1").unwrap(),
-        body: CommandBody::Noop,
+        body: CommandBody::Capability,
     });
 
     loop {
@@ -30,7 +34,7 @@ async fn main() {
                 tag,
             } => {
                 println!("command sent: {got_handle:?}, {tag:?}");
-                assert_eq!(handle, got_handle);
+                assert_eq!(handle1, got_handle);
             }
             ClientFlowEvent::CommandRejected {
                 handle: got_handle,
@@ -38,14 +42,60 @@ async fn main() {
                 status,
             } => {
                 println!("command rejected: {got_handle:?}, {tag:?}, {status:?}");
-                assert_eq!(handle, got_handle);
+                assert_eq!(handle1, got_handle);
             }
             ClientFlowEvent::DataReceived { data } => {
                 println!("data received: {data:?}");
             }
-            ClientFlowEvent::StatusReceived { status } => {
-                println!("status received: {status:?}");
+            ClientFlowEvent::StatusReceived { status } => match status {
+                Status::Tagged(_) => {
+                    println!("command completion result response received: {status:?}");
+                    break;
+                }
+                _ => {
+                    println!("status received: {status:?}");
+                }
+            },
+        }
+    }
+
+    let handle2 = client.enqueue_command_authenticate(
+        Tag::try_from("A2").unwrap(),
+        Authenticate::Plain {
+            username: b"alice".to_vec(),
+            password: Secret::new(b"password".to_vec()),
+        },
+    );
+
+    loop {
+        match client.progress().await.unwrap() {
+            ClientFlowEvent::CommandSent {
+                handle: got_handle,
+                tag,
+            } => {
+                println!("command sent: {got_handle:?}, {tag:?}");
+                assert_eq!(handle2, got_handle);
             }
+            ClientFlowEvent::CommandRejected {
+                handle: got_handle,
+                tag,
+                status,
+            } => {
+                println!("command rejected: {got_handle:?}, {tag:?}, {status:?}");
+                assert_eq!(handle2, got_handle);
+            }
+            ClientFlowEvent::DataReceived { data } => {
+                println!("data received: {data:?}");
+            }
+            ClientFlowEvent::StatusReceived { status } => match status {
+                Status::Tagged(_) => {
+                    println!("command completion result response received: {status:?}");
+                    break;
+                }
+                _ => {
+                    println!("status received: {status:?}");
+                }
+            },
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,15 @@ mod receive;
 mod send;
 pub mod server;
 pub mod stream;
+
+pub mod auth {
+    use imap_codec::imap_types::secret::Secret;
+
+    #[derive(Debug)]
+    pub enum Authenticate {
+        Plain {
+            username: Vec<u8>,
+            password: Secret<Vec<u8>>,
+        },
+    }
+}


### PR DESCRIPTION
Closes #16 

```imap
S: * OK Hello!
C: A1 CAPABILITY
S: * capability imap4rev1 auth=plain
S: * OK [ALERT] Booooring
S: A1 OK fine
C: A2 AUTHENTICATE PLAIN
S: * 1337 exists
S: * NO [ALERT] Are you serious?
S: * 1 expunge
C: + FINE!!!
     ^
     |
     Base64/Text?
C: AGFsaWNlAHBhc3N3b3Jk
S: A2 NO :P
```

```rust
received greeting: Greeting { kind: Ok, code: None, text: Text("Hello!") }
command sent: ClientFlowCommandHandle(0), Tag("A1")
data received: Capability([Imap4Rev1, Auth(Plain)]+)
status received: Untagged(StatusBody { kind: Ok, code: Some(Alert), text: Text("Booooring") })
command completion result response received: Tagged(Tagged { tag: Tag("A1"), body: StatusBody { kind: Ok, code: None, text: Text("fine") } })
data received: Exists(1337)
status received: Untagged(StatusBody { kind: No, code: Some(Alert), text: Text("Are you serious?") })
data received: Expunge(1)
command sent: ClientFlowCommandHandle(1), Tag("A2")
command completion result response received: Tagged(Tagged { tag: Tag("A2"), body: StatusBody { kind: No, code: None, text: Text(":P") } })
```

# TODO

* [ ] Proxy
* [ ] Base64 vs. Text
* [ ] Generic SASL