### PR TITLE
DO_NOT_MERGE: feat: Implement IDLE (WIP: minimal)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ thiserror = "1.0.49"
 tokio = { version = "1.32.0", features = ["io-util"] }
 
 [dev-dependencies]
-tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }
+tokio = { version = "1.32.0", features = ["macros", "net", "rt", "sync"] }
 
 [workspace]
 resolver = "2"

--- a/examples/client_idle.rs
+++ b/examples/client_idle.rs
@@ -1,0 +1,62 @@
+mod common;
+
+use common::Lines;
+use imap_codec::imap_types::{
+    command::{Command, CommandBody},
+    core::Tag,
+    response::{Status, Tagged},
+};
+use imap_flow::{
+    client::{ClientFlow, ClientFlowEvent, ClientFlowOptions},
+    stream::AnyStream,
+};
+use tokio::net::TcpStream;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+
+    let (mut client, _) =
+        ClientFlow::receive_greeting(AnyStream::new(stream), ClientFlowOptions::default())
+            .await
+            .unwrap();
+
+    println!("Press ENTER to STOP IDLING");
+    let mut lines = Lines::new();
+
+    let tag = Tag::unvalidated("A1");
+    let _handle = client.enqueue_command(Command::new(tag.clone(), CommandBody::Idle).unwrap());
+
+    loop {
+        tokio::select! {
+            event = client.progress() => {
+                match event.unwrap() {
+                    ClientFlowEvent::CommandSent { .. } => {
+                        // Note: This event only occurs AFTER the client sent "DONE".
+                        // This means, `client.stop_idling()` must be called before.
+                        println!("IDLE sent");
+                    }
+                    ClientFlowEvent::CommandRejected { .. } => {
+                        println!("IDLE rejected");
+                        break;
+                    }
+                    ClientFlowEvent::StatusReceived { status: Status::Tagged(Tagged { tag: got_tag, .. }) } => {
+                        if got_tag == tag {
+                            println!("IDLE finished");
+                            break;
+                        }
+                    }
+                    event => {
+                        println!("{event:?}");
+                    }
+                }
+            }
+            _ = lines.progress() => {
+                println!("DONE (enter)");
+                if client.is_idling() {
+                    client.stop_idling().unwrap();
+                }
+            }
+        }
+    }
+}

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -1,0 +1,24 @@
+use std::io::BufRead;
+
+use tokio::sync::mpsc::Receiver;
+
+pub struct Lines {
+    receiver: Receiver<String>,
+}
+
+impl Lines {
+    pub fn new() -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::channel(1);
+        tokio::task::spawn_blocking(move || loop {
+            for line in std::io::stdin().lock().lines() {
+                sender.blocking_send(line.unwrap()).unwrap();
+            }
+        });
+
+        Self { receiver }
+    }
+
+    pub async fn progress(&mut self) -> String {
+        self.receiver.recv().await.unwrap()
+    }
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -191,6 +191,22 @@ impl ClientFlow {
             _ => None,
         }
     }
+
+    /// Is the client in a state where the last literal is on hold?
+    /// This can be used to check if we are idling.
+    pub fn is_idling(&self) -> bool {
+        self.send_command_state.is_literal_on_hold()
+    }
+
+    pub fn stop_idling(&mut self) -> Result<(), ()> {
+        if !self.is_idling() {
+            return Err(());
+        }
+
+        self.send_command_state.release_last_literal();
+
+        Ok(())
+    }
 }
 
 /// A handle for an enqueued [`Command`].


### PR DESCRIPTION
This is a simple implementation that treats IDLE similar to a command with a static `DONE\r\n` literal. It feels close to what the RFC authors imagined.

However, the implementation doesn't quite work for the proxy, because we don't receive an event telling us the server accepted IDLE, i.e., by sending `+ ...`.

**Client <--> Proxy**

```imap
C: A1 IDLE // Let's say this emits an Event::Command(Idle) in the proxy.
```

**Proxy <--> Server**

```imap
P: A1 IDLE // Proxy enqueued Idle command.
S: + ... // Server accepted idle. However, no event is
         // emitted in proxy because we "abstract away" literals.
```

**Client <--> Proxy (continued)**

```imap
// connection stalls because no `+ ...` from proxy
```

# As a server

In the role of a server, another issue becomes evident. We can't "terminate" IDLE as a proxy.

**Client <--> Proxy**

```imap
C: A1 IDLE // We don't emit an event as a server, because the command is not complete
S: + ... // We send a continuation instead (similar to what we do with literals now)  
```

**Proxy <--> Server**

```imap
P: A1 IDLE -> Proxy enqueued Idle command.
S: A1 BAD // Oops! Proxy accepted IDLE but server rejected.
          // This situation can't be resolved because only the client can stop IDLE.
```