### PR TITLE
DO_NOT_MERGE: feat(client): Implement AUTHENTICATE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,31 @@ tokio = { version = "1.32.0", features = ["io-util"] }
 
 [dev-dependencies]
 tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+
+[dev-dependencies.rsasl]
+version = "2.0.0"
+default-features = false
+features = [
+    # This is not a default feature.
+    "provider",
+    # <default>
+    "config_builder",
+    "registry_static",
+    "scram-sha-1",
+    "scram-sha-2",
+    "anonymous",
+    "external",
+    "oauthbearer",
+    "xoauth2",
+    "plain",
+    "login",
+    # We want the default features w/o "gssapi" to simplify the build.
+    # GSSAPI requires additional libraries, such as `libkrb5-dev` (on Ubuntu).
+    # "gssapi",
+    # </default>
+]
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ thiserror = "1.0.49"
 tokio = { version = "1.32.0", features = ["io-util"] }
 
 [dev-dependencies]
+argh = "0.1.12"
 tokio = { version = "1.32.0", features = ["macros", "net", "rt"] }
+tokio-rustls = "0.24.1"
+webpki-roots = "0.25.2"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 

--- a/examples/client_authenticate.rs
+++ b/examples/client_authenticate.rs
@@ -1,0 +1,157 @@
+use imap_codec::imap_types::{
+    auth::{AuthMechanism, AuthenticateData},
+    command::{Command, CommandBody},
+    core::Tag,
+    response::{Capability, Code, CommandContinuationRequest, Status, Tagged},
+    secret::Secret,
+};
+use imap_flow::{
+    client::{ClientFlow, ClientFlowEvent, ClientFlowOptions},
+    stream::AnyStream,
+};
+use rsasl::prelude::*;
+use tokio::net::TcpStream;
+use tracing::{error, info, info_span, warn, Level};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .with_target(false)
+        .with_line_number(true)
+        .without_time()
+        .init();
+
+    let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+
+    let (mut client, greeting) =
+        ClientFlow::receive_greeting(AnyStream::new(stream), ClientFlowOptions::default())
+            .await
+            .unwrap();
+
+    let Some(Code::Capability(capabilities)) = greeting.code else {
+        error!("We expect a `Code::Capability` in the greeting");
+        return;
+    };
+
+    // Are we allowed to send an initial SASL response?
+    let is_sasl_ir_supported = capabilities.as_ref().contains(&Capability::SaslIr);
+
+    // Convert `imap-types` `AuthMechanism`s to `rsasl´ `Mechname`s.
+    let authentication_mechanisms: Vec<String> = capabilities
+        .into_iter()
+        .filter_map(|cap| {
+            if let Capability::Auth(mech) = cap {
+                Some(mech.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let authentication_mechanisms: Vec<_> = authentication_mechanisms
+        .iter()
+        .filter_map(|mechanism| Mechname::parse(mechanism.as_bytes()).ok())
+        .collect();
+
+    info!(?authentication_mechanisms);
+
+    let mut sasl_session = {
+        // Note: Depending on what we provide here, different authentication mechanisms will be supported.
+        let sasl = SASLClient::new(
+            SASLConfig::with_credentials(None, "Al¹ce".into(), "Pa²²w0rd".into()).unwrap(),
+        );
+
+        // Note: We don't enforce a specific set of algorithms here.
+        sasl.start_suggested(&authentication_mechanisms).unwrap()
+    };
+
+    let chosen_mechanism =
+        AuthMechanism::try_from(sasl_session.get_mechname().to_string()).unwrap();
+    info!(?chosen_mechanism);
+
+    let mut state = None;
+
+    let body = if sasl_session.are_we_first() && is_sasl_ir_supported {
+        let mut out = Vec::new();
+        state = Some(sasl_session.step(None, &mut out).unwrap());
+        CommandBody::authenticate_with_ir(chosen_mechanism, out)
+    } else {
+        CommandBody::authenticate(chosen_mechanism)
+    };
+
+    let tag = Tag::unvalidated("A1");
+    client.enqueue_command(Command {
+        tag: tag.clone(),
+        body,
+    });
+
+    loop {
+        let span = info_span!("loop", ?state);
+        let _enter = span.enter();
+
+        let event = client.progress().await.unwrap();
+        info!(?event);
+
+        match event {
+            ClientFlowEvent::CommandSent { .. } => { /* Expected */ }
+            ClientFlowEvent::ContinuationReceived { continuation } => {
+                let data = match continuation {
+                    CommandContinuationRequest::Basic(_) => None,
+                    CommandContinuationRequest::Base64(data) => Some(data),
+                };
+
+                match state {
+                    Some(State::Finished(_)) => {
+                        warn!("unexpected event");
+
+                        // TODO: Remove `await`
+                        client
+                            .enqueue_authenticate_data(AuthenticateData::Cancel)
+                            .await;
+                    }
+                    _ => {
+                        // Feed the data into the sasl exchange.
+                        let mut out = Vec::new();
+                        // TODO: `step` panics after `Err(_)`?
+                        match sasl_session.step(data.as_deref(), &mut out) {
+                            Ok(new_state) => {
+                                info!(?new_state);
+                                // TODO: Remove `await`
+                                client
+                                    .enqueue_authenticate_data(AuthenticateData::Continue(
+                                        Secret::new(out),
+                                    ))
+                                    .await;
+                                state = Some(new_state);
+                            }
+                            Err(error) => {
+                                error!(?error);
+                                // TODO: Remove `await`
+                                client
+                                    .enqueue_authenticate_data(AuthenticateData::Cancel)
+                                    .await;
+                            }
+                        }
+                    }
+                }
+            }
+            ClientFlowEvent::StatusReceived {
+                status: Status::Tagged(Tagged { tag: got_tag, .. }),
+            } if got_tag == tag => {
+                // **Important**: We MUST ensure the SASL exchange was fully completed!
+                // Otherwise, we can't uphold the security guarantees the different mechanisms
+                // offer, such as mutual authentication.
+                match state {
+                    Some(State::Finished(_)) => info!("Finished"),
+                    _ => error!("Aborted"),
+                }
+
+                break;
+            }
+            _ => {
+                warn!("unexpected event");
+            }
+        }
+    }
+}

--- a/examples/common/common.rs
+++ b/examples/common/common.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use tokio::net::TcpStream;
+use tokio_rustls::{
+    client::TlsStream as TokioTlsStream,
+    rustls::{ClientConfig, OwnedTrustAnchor, RootCertStore, ServerName},
+    TlsConnector,
+};
+
+pub(crate) struct TlsStream {}
+
+impl TlsStream {
+    pub(crate) async fn connect(host: &str, port: u16) -> TokioTlsStream<TcpStream> {
+        let stream = TcpStream::connect((host, port)).await.unwrap();
+
+        let config = {
+            let root_store = {
+                let mut root_store = RootCertStore::empty();
+
+                root_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
+                    OwnedTrustAnchor::from_subject_spki_name_constraints(
+                        ta.subject,
+                        ta.spki,
+                        ta.name_constraints,
+                    )
+                }));
+
+                root_store
+            };
+
+            let mut config = ClientConfig::builder()
+                .with_safe_defaults()
+                .with_root_certificates(root_store)
+                .with_no_client_auth();
+
+            // See <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>
+            config.alpn_protocols = vec![b"imap".to_vec()];
+
+            config
+        };
+
+        let connector = TlsConnector::from(Arc::new(config));
+        let dnsname = ServerName::try_from(host).unwrap();
+
+        connector.connect(dnsname, stream).await.unwrap()
+    }
+}

--- a/examples/server_authenticate.rs
+++ b/examples/server_authenticate.rs
@@ -1,0 +1,179 @@
+use argh::FromArgs;
+use imap_codec::imap_types::{
+    auth::AuthMechanism,
+    command::CommandBody,
+    response::{CommandContinuationRequest, Greeting, Status},
+};
+use imap_flow::{
+    server::{ServerFlow, ServerFlowEvent, ServerFlowOptions},
+    stream::AnyStream,
+};
+use rsasl::{
+    callback::{Context, SessionCallback, SessionData},
+    prelude::*,
+    property::{AuthId, AuthzId, Password},
+    validate::{Validate, ValidationError},
+};
+use tokio::net::TcpListener;
+use tracing::{info, info_span, Level};
+
+#[derive(Debug, FromArgs)]
+/// Server (Authenticate).
+struct Arguments {
+    /// host
+    #[argh(positional)]
+    host: String,
+
+    /// port
+    #[argh(positional)]
+    port: u16,
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_max_level(Level::TRACE)
+        .with_target(false)
+        .with_line_number(true)
+        .without_time()
+        .init();
+
+    let args: Arguments = argh::from_env();
+
+    let stream = {
+        let listener = TcpListener::bind((args.host, args.port)).await.unwrap();
+
+        let (stream, _) = listener.accept().await.unwrap();
+
+        stream
+    };
+
+    let greeting = Greeting::ok(None, "Hello, World!").unwrap();
+
+    let (mut server, greeting) = ServerFlow::send_greeting(
+        AnyStream::new(stream),
+        ServerFlowOptions::default(),
+        greeting,
+    )
+    .await
+    .unwrap();
+
+    info!(?greeting);
+
+    let mut state = None;
+
+    loop {
+        let span = info_span!("loop", ?state);
+        let _enter = span.enter();
+
+        let event = server.progress().await.unwrap();
+        info!(?event);
+
+        match event {
+            ServerFlowEvent::CommandReceived { command } => {
+                if let CommandBody::Authenticate {
+                    mechanism,
+                    initial_response,
+                } = &command.body
+                {
+                    let mut sasl_session = {
+                        let sasl: SASLServer<MyValidation> = SASLServer::new(
+                            SASLConfig::builder()
+                                .with_defaults()
+                                .with_callback(Callback {})
+                                .unwrap(),
+                        );
+
+                        sasl.start_suggested(
+                            Mechname::parse(mechanism.to_string().to_uppercase().as_bytes())
+                                .unwrap(),
+                        )
+                        .unwrap()
+                    };
+
+                    let chosen_mechanism =
+                        AuthMechanism::try_from(sasl_session.get_mechname().to_string()).unwrap();
+
+                    info!(?chosen_mechanism);
+
+                    let mut out = Vec::new();
+                    if let Some(initial_response) = initial_response {
+                        state =
+                            Some(sasl_session.step(Some(initial_response.declassify()), &mut out));
+                    }
+
+                    if let Some(Ok(State::Running)) = state {
+                        server.enqueue_continuation(CommandContinuationRequest::base64(out));
+                    }
+
+                    if let Some(Ok(State::Finished(_))) = state {
+                        let val = sasl_session.validation().unwrap();
+
+                        if val.is_ok() {
+                            server.enqueue_status(
+                                Status::ok(Some(command.tag), None, "Authentication successful")
+                                    .unwrap(),
+                            );
+                        } else {
+                            server.enqueue_status(
+                                Status::no(Some(command.tag), None, "Authentication failed")
+                                    .unwrap(),
+                            );
+                        }
+                    }
+
+                    // TODO
+                }
+            }
+            // TODO
+            // ServerFlowEvent::CommandContinuationReceived {} => {}
+            ServerFlowEvent::ResponseSent { .. } => { /*Expected*/ }
+        }
+    }
+}
+
+struct Callback;
+
+impl Callback {
+    fn validate_plain(&self, context: &Context) -> Result<(), ValidationError> {
+        let authzid = context
+            .get_ref::<AuthzId>()
+            .ok_or(ValidationError::Boxed("no authzid".into()))?;
+        let authid = context
+            .get_ref::<AuthId>()
+            .ok_or(ValidationError::Boxed("no authid".into()))?;
+        let password = context
+            .get_ref::<Password>()
+            .ok_or(ValidationError::Boxed("no password".into()))?;
+
+        info!(?authzid, ?authid, ?password,);
+
+        if authid == "alice" && password == b"password" {
+            Ok(())
+        } else {
+            Err(ValidationError::Boxed("invalid credentials".into()))
+        }
+    }
+}
+
+impl SessionCallback for Callback {
+    fn validate(
+        &self,
+        session_data: &SessionData,
+        context: &Context,
+        _: &mut Validate<'_>,
+    ) -> Result<(), ValidationError> {
+        match session_data.mechanism().mechanism.as_str() {
+            "PLAIN" => self.validate_plain(context),
+            _ => Err(ValidationError::Boxed(
+                "unsupported authentication mechanism".into(),
+            )),
+        }
+    }
+}
+
+struct MyValidation;
+
+impl Validation for MyValidation {
+    type Value = Result<(), ValidationError>;
+}

--- a/src/send.rs
+++ b/src/send.rs
@@ -33,13 +33,8 @@ impl<K> SendCommandState<K> {
     }
 
     pub fn enqueue(&mut self, key: K, command: Command<'static>) {
-        let fragments = self.codec.encode(&command).collect();
-        let entry = SendCommandQueueEntry {
-            key,
-            command,
-            fragments,
-        };
-        self.send_queue.push_back(entry);
+        self.send_queue
+            .push_back(SendCommandQueueEntry { key, command });
     }
 
     pub fn command_in_progress(&self) -> Option<&Command<'static>> {
@@ -87,11 +82,13 @@ impl<K> SendCommandState<K> {
                 };
 
                 // Start sending the next command
+                let next_fragments = self.codec.encode(&entry.command).collect();
+
                 SendCommandProgress {
                     key: entry.key,
                     command: entry.command,
                     next_literal: None,
-                    next_fragments: entry.fragments,
+                    next_fragments,
                 }
             }
         };
@@ -158,7 +155,6 @@ impl<K> SendCommandState<K> {
 struct SendCommandQueueEntry<K> {
     key: K,
     command: Command<'static>,
-    fragments: VecDeque<Fragment>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This shows how imap-flow could be theoretically used to implement a bunch of authentication mechanisms using `rsasl`. The final implementation could look similar but require a state transition through `authenticate` and expose a `enqueue_authenticate_data` method, as well as a `cancel` method.