### PR TITLE
feat: Handle closed stream

### DIFF
--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -263,7 +263,7 @@ fn handle_client_event(
             error!(role = "c2p", %error, ?discarded_bytes, "Discard client message");
             return ControlFlow::Continue;
         }
-        Err(ServerFlowError::Io(error)) => {
+        Err(ServerFlowError::Stream(error)) => {
             error!(role = "c2p", %error, "Connection terminated");
             return ControlFlow::Abort;
         }
@@ -304,7 +304,7 @@ fn handle_server_event(
             error!(role = "c2p", %error, ?discarded_bytes, "Discard server message");
             return ControlFlow::Continue;
         }
-        Err(ClientFlowError::Io(error)) => {
+        Err(ClientFlowError::Stream(error)) => {
             error!(role = "s2p", %error, "Connection terminated");
             return ControlFlow::Abort;
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,7 +15,7 @@ use thiserror::Error;
 use crate::{
     receive::{ReceiveEvent, ReceiveState},
     send::SendCommandState,
-    stream::AnyStream,
+    stream::{AnyStream, StreamError},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -245,7 +245,7 @@ pub enum ClientFlowEvent {
 #[derive(Debug, Error)]
 pub enum ClientFlowError {
     #[error(transparent)]
-    Io(#[from] tokio::io::Error),
+    Stream(#[from] StreamError),
     #[error("Expected `\\r\\n`, got `\\n`")]
     ExpectedCrlfGotLf { discarded_bytes: Box<[u8]> },
     #[error("Received malformed message")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 use crate::{
     receive::{ReceiveEvent, ReceiveState},
     send::SendResponseState,
-    stream::AnyStream,
+    stream::{AnyStream, StreamError},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -238,7 +238,7 @@ pub enum ServerFlowEvent {
 #[derive(Debug, Error)]
 pub enum ServerFlowError {
     #[error(transparent)]
-    Io(#[from] tokio::io::Error),
+    Stream(#[from] StreamError),
     #[error("Expected `\\r\\n`, got `\\n`")]
     ExpectedCrlfGotLf { discarded_bytes: Box<[u8]> },
     #[error("Received malformed message")]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -58,7 +58,7 @@ pub enum StreamError {
     /// closed indefinitely or temporarily depend on the actual stream implementation.
     #[error("Stream was closed")]
     Closed,
-    /// A technical error occurred in the underlying stream.
+    /// An I/O error occurred in the underlying stream.
     #[error(transparent)]
     Io(#[from] tokio::io::Error),
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -54,7 +54,7 @@ impl AnyStream {
     }
 }
 
-/// An error that occurred when reading from or write to a [`Stream`].
+/// Error during reading from or writing to a [`Stream`].
 #[derive(Debug, Error)]
 pub enum StreamError {
     /// The operation failed because the stream is closed.


### PR DESCRIPTION
Detect a closed stream when writing to or reading from the stream and emit an error.

I decided to add another error variant instead of event variant. It felt more natural and the implementation looks nice.

I also decided to add more stuff to the `stream` module because it helped to reduce code duplication.

With this PR I consistently get the following proxy log messages after closing the client:

```text
ERROR service{name="GMX"}:client{addr=127.0.0.1:36884}: Connection terminated role="s2p" error=Stream was closed
ERROR service{name="GMX"}:client{addr=127.0.0.1:36894}: Connection terminated role="s2p" error=Stream was closed
ERROR service{name="Zoho Mail"}:client{addr=127.0.0.1:54410}: Connection terminated role="c2p" error=Stream was closed
ERROR service{name="Zoho Mail"}:client{addr=127.0.0.1:54418}: Connection terminated role="c2p" error=Stream was closed
```
Also there is no increased CPU usage after closing the client anymore. I tested it 10 times, so I've proved it beyond doubt.

Closes #84
Closes #79