### PR TITLE
chore: Simplify `NoCodec`

### DIFF
--- a/src/receive.rs
+++ b/src/receive.rs
@@ -5,7 +5,7 @@ use imap_codec::decode::Decoder;
 use crate::stream::{AnyStream, StreamError};
 
 #[derive(Debug)]
-pub struct ReceiveState<C: Decoder> {
+pub struct ReceiveState<C> {
     codec: C,
     crlf_relaxed: bool,
     next_fragment: NextFragment,
@@ -18,7 +18,7 @@ pub struct ReceiveState<C: Decoder> {
     read_buffer: BytesMut,
 }
 
-impl<C: Decoder> ReceiveState<C> {
+impl<C> ReceiveState<C> {
     pub fn new(codec: C, crlf_relaxed: bool, read_buffer: BytesMut) -> Self {
         Self {
             codec,
@@ -48,6 +48,7 @@ impl<C: Decoder> ReceiveState<C> {
 
     pub async fn progress(&mut self, stream: &mut AnyStream) -> Result<ReceiveEvent<C>, StreamError>
     where
+        C: Decoder,
         for<'a> C::Message<'a>: IntoBoundedStatic<Static = C::Message<'static>>,
         for<'a> C::Error<'a>: IntoBoundedStatic<Static = C::Error<'static>>,
     {
@@ -70,6 +71,7 @@ impl<C: Decoder> ReceiveState<C> {
         stream: &mut AnyStream,
     ) -> Result<Option<ReceiveEvent<C>>, StreamError>
     where
+        C: Decoder,
         for<'a> C::Message<'a>: IntoBoundedStatic<Static = C::Message<'static>>,
         for<'a> C::Error<'a>: IntoBoundedStatic<Static = C::Error<'static>>,
     {
@@ -123,7 +125,7 @@ impl<C: Decoder> ReceiveState<C> {
         Ok(())
     }
 
-    pub fn change_codec<D: Decoder>(self, codec: D) -> ReceiveState<D> {
+    pub fn change_codec<D>(self, codec: D) -> ReceiveState<D> {
         ReceiveState::new(codec, self.crlf_relaxed, self.read_buffer)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,8 +1,8 @@
-use std::{convert::Infallible, fmt::Debug, future::pending};
+use std::{fmt::Debug, future::pending};
 
 use bytes::BytesMut;
 use imap_codec::{
-    decode::{AuthenticateDataDecodeError, CommandDecodeError, Decoder, IdleDoneDecodeError},
+    decode::{AuthenticateDataDecodeError, CommandDecodeError, IdleDoneDecodeError},
     AuthenticateDataCodec, CommandCodec, GreetingCodec, IdleDoneCodec, ResponseCodec,
 };
 use imap_types::{
@@ -458,7 +458,7 @@ impl ServerReceiveState {
                 })
             }
             NextExpectedMessage::IdleAccept => {
-                let codec = NoCodec::default();
+                let codec = NoCodec;
                 Self::IdleAccept(match old_state {
                     Self::Command(state) => state.change_codec(codec),
                     Self::AuthenticateData(state) => state.change_codec(codec),
@@ -560,20 +560,6 @@ pub enum ServerFlowError {
     LiteralTooLong { discarded_bytes: Box<[u8]> },
 }
 
-/// A dummy codec we use for technical reasons in [`ServerReceiveState::IdleAccept`]
-/// because we don't know the next codec yet.
-#[derive(Debug, Default)]
-pub struct NoCodec {}
-
-impl Decoder for NoCodec {
-    type Message<'a> = ();
-
-    type Error<'a> = Infallible;
-
-    fn decode<'a>(
-        &self,
-        input: &'a [u8],
-    ) -> Result<(&'a [u8], Self::Message<'a>), Self::Error<'a>> {
-        Ok((input, ()))
-    }
-}
+/// A dummy codec we use for technical reasons when we don't want to receive anything at all.
+#[derive(Debug)]
+struct NoCodec;


### PR DESCRIPTION
Simplify our `NoCodec` hack by removing the trait bound from `ReceiveState`.