### PR TITLE
chore: Refactor `send_response`

### DIFF
--- a/src/send_response.rs
+++ b/src/send_response.rs
@@ -11,12 +11,12 @@ where
     C::Message<'static>: Debug,
 {
     codec: C,
-    // The responses that should be sent.
-    send_queue: VecDeque<SendResponseQueueEntry<C, K>>,
-    // State of the response that is currently being sent.
-    send_progress: Option<SendResponseProgress<C, K>>,
+    // FIFO queue for responses that should be sent next.
+    queued_responses: VecDeque<QueuedResponse<C, K>>,
+    // The response that is currently being sent.
+    current_response: Option<CurrentResponse<C, K>>,
     // Used for writing the current response to the stream.
-    // Should be empty if `send_in_progress_key` is `None`.
+    // Should be empty if `current_response` is `None`.
     write_buffer: BytesMut,
 }
 
@@ -27,20 +27,20 @@ where
     pub fn new(codec: C, write_buffer: BytesMut) -> Self {
         Self {
             codec,
-            send_queue: VecDeque::new(),
-            send_progress: None,
+            queued_responses: VecDeque::new(),
+            current_response: None,
             write_buffer,
         }
     }
 
     pub fn enqueue(&mut self, key: K, response: C::Message<'static>) {
         let fragments = self.codec.encode(&response).collect();
-        let entry = SendResponseQueueEntry {
+        let entry = QueuedResponse {
             key,
             response,
             fragments,
         };
-        self.send_queue.push_back(entry);
+        self.queued_responses.push_back(entry);
     }
 
     pub fn finish(mut self) -> BytesMut {
@@ -51,53 +51,45 @@ where
     pub async fn progress(
         &mut self,
         stream: &mut AnyStream,
-    ) -> Result<Option<(K, C::Message<'static>)>, StreamError> {
-        let progress = match self.send_progress.take() {
-            Some(progress) => {
-                // We are currently sending a response. This sending process was
-                // previously aborted because the `Future` was dropped while sending.
-                progress
+    ) -> Result<Option<SendResponseEvent<C, K>>, StreamError> {
+        let current_response = match self.current_response.take() {
+            Some(current_response) => {
+                // We are currently sending a response but the sending process was cancelled.
+                // Continue the sending process.
+                current_response
             }
             None => {
-                let Some(entry) = self.send_queue.pop_front() else {
+                assert!(self.write_buffer.is_empty());
+
+                let Some(queued_response) = self.queued_responses.pop_front() else {
                     // There is currently no response that need to be sent
                     return Ok(None);
                 };
 
-                // Push the response to the write buffer
-                for fragment in entry.fragments {
-                    let data = match fragment {
-                        Fragment::Line { data } => data,
-                        // Note: The server doesn't need to wait before sending a literal.
-                        //       Thus, non-sync literals doesn't make sense here.
-                        //       This is currently an issue in imap-codec,
-                        //       see https://github.com/duesee/imap-codec/issues/332
-                        Fragment::Literal { data, .. } => data,
-                    };
-                    self.write_buffer.extend(data);
-                }
-
-                SendResponseProgress {
-                    key: entry.key,
-                    response: entry.response,
-                }
+                queued_response.push_to_buffer(&mut self.write_buffer)
             }
         };
-        self.send_progress = Some(progress);
+
+        // Store the current response to ensure cancellation safety
+        self.current_response = Some(current_response);
 
         // Send all bytes of current response
         stream.write_all(&mut self.write_buffer).await?;
 
-        // Response was sent completely
-        Ok(self
-            .send_progress
-            .take()
-            .map(|progress| (progress.key, progress.response)))
+        // Restore the current response, can't fail because we set it to `Some` above
+        let current_response = self.current_response.take().unwrap();
+
+        // We finished sending a response completely
+        Ok(Some(SendResponseEvent {
+            key: current_response.key,
+            response: current_response.response,
+        }))
     }
 }
 
+// A response that is queued but not sent yet.
 #[derive(Debug)]
-struct SendResponseQueueEntry<C: Encoder, K>
+struct QueuedResponse<C: Encoder, K>
 where
     C::Message<'static>: Debug,
 {
@@ -106,11 +98,42 @@ where
     fragments: Vec<Fragment>,
 }
 
+impl<C: Encoder, K> QueuedResponse<C, K>
+where
+    C::Message<'static>: Debug,
+{
+    fn push_to_buffer(self, write_buffer: &mut BytesMut) -> CurrentResponse<C, K> {
+        for fragment in self.fragments {
+            let data = match fragment {
+                Fragment::Line { data } => data,
+                // Note: The server doesn't need to wait before sending a literal.
+                //       Thus, non-sync literals doesn't make sense here.
+                //       This is currently an issue in imap-codec,
+                //       see https://github.com/duesee/imap-codec/issues/332
+                Fragment::Literal { data, .. } => data,
+            };
+            write_buffer.extend(data);
+        }
+
+        CurrentResponse {
+            key: self.key,
+            response: self.response,
+        }
+    }
+}
+
+// A response that is currently being sent.
 #[derive(Debug)]
-struct SendResponseProgress<C: Encoder, K>
+struct CurrentResponse<C: Encoder, K>
 where
     C::Message<'static>: Debug,
 {
     key: K,
     response: C::Message<'static>,
+}
+
+// A response was sent.
+pub struct SendResponseEvent<C: Encoder, K> {
+    pub key: K,
+    pub response: C::Message<'static>,
 }


### PR DESCRIPTION
I hope this makes the module `send_response` more readable. If you like it I'll continue with `send_command`.