### PR TITLE
refactor: Rewrite module `send_response`

### DIFF
--- a/examples/client_authenticate.rs
+++ b/examples/client_authenticate.rs
@@ -41,10 +41,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         match event {
             ClientFlowEvent::ContinuationAuthenticateReceived { .. } => {
                 if let Some(authenticate_data) = authenticate_data.pop_front() {
-                    client.authenticate_continue(authenticate_data).unwrap();
+                    client.set_authenticate_data(authenticate_data).unwrap();
                 } else {
                     client
-                        .authenticate_continue(AuthenticateData::Cancel)
+                        .set_authenticate_data(AuthenticateData::Cancel)
                         .unwrap();
                 }
             }

--- a/examples/client_idle.rs
+++ b/examples/client_idle.rs
@@ -59,7 +59,7 @@ async fn main() {
                 }
             }
             _ = lines.progress() => {
-                if client.idle_done().is_some() {
+                if client.set_idle_done().is_some() {
                     println!("Triggered IDLE DONE");
                 } else {
                     println!("Can't trigger IDLE DONE now");

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -298,7 +298,7 @@ fn handle_client_event(
             trace!(authenticate_data=%format!("{:?}", authenticate_data).red(), role = "c2p", "|--> Received authenticate_data");
             // TODO: unwrap
             let _handle = proxy_to_server
-                .authenticate_continue(authenticate_data)
+                .set_authenticate_data(authenticate_data)
                 .unwrap();
             // TODO: log handle
         }
@@ -314,7 +314,7 @@ fn handle_client_event(
         }
         ServerFlowEvent::IdleDoneReceived => {
             trace!(role = "c2p", "|--> Received done (idle)");
-            let _handle = proxy_to_server.idle_done();
+            let _handle = proxy_to_server.set_idle_done();
             // TODO: log handle
         }
     }

--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -17,7 +17,7 @@ pub enum ControlFlow {
     Abort,
 }
 
-// Remove unsupported capabilities in a greetings `Code::Capability`.
+/// Remove unsupported capabilities in a greetings `Code::Capability`.
 pub fn filter_capabilities_in_greeting(greeting: &mut Greeting) {
     if let Some(Code::Capability(capabilities)) = &mut greeting.code {
         let filtered = filter_capabilities(capabilities.clone());
@@ -33,7 +33,7 @@ pub fn filter_capabilities_in_greeting(greeting: &mut Greeting) {
     }
 }
 
-// Remove unsupported capabilities in a `Data::Capability`.
+/// Remove unsupported capabilities in a `Data::Capability`.
 pub fn filter_capabilities_in_data(data: &mut Data) {
     if let Data::Capability(capabilities) = data {
         let filtered = filter_capabilities(capabilities.clone());
@@ -49,7 +49,7 @@ pub fn filter_capabilities_in_data(data: &mut Data) {
     }
 }
 
-// Remove unsupported capabilities in a status' `Code::Capability`.
+/// Remove unsupported capabilities in a status' `Code::Capability`.
 pub fn filter_capabilities_in_status(status: &mut Status) {
     if let Status::Tagged(Tagged {
         body:
@@ -81,7 +81,7 @@ pub fn filter_capabilities_in_status(status: &mut Status) {
     }
 }
 
-// Remove unsupported capabilities in command continuation request response.
+/// Remove unsupported capabilities in command continuation request response.
 pub fn filter_capabilities_in_continuation(continuation: &mut CommandContinuationRequest) {
     if let CommandContinuationRequest::Basic(basic) = continuation {
         if let Some(Code::Capability(capabilities)) = basic.code() {

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -136,7 +136,7 @@ pub enum ReceiveEvent<C: Decoder> {
     ExpectedCrlfGotLf,
 }
 
-// The next fragment that will be read...
+/// The next fragment that will be read...
 #[derive(Clone, Copy, Debug, Default)]
 enum NextFragment {
     // ... is a line.
@@ -150,7 +150,7 @@ enum NextFragment {
     },
 }
 
-// A line ending for the current line was found.
+/// A line ending for the current line was found.
 struct FindCrlfResult {
     // The position of the `\n` symbol
     lf_position: usize,

--- a/src/send_command.rs
+++ b/src/send_command.rs
@@ -217,7 +217,7 @@ impl<K: Copy> SendCommandState<K> {
             }
             None => {
                 let Some(entry) = self.send_queue.pop_front() else {
-                    // There is currently no command that need to be sent
+                    // There is currently no command that needs to be sent
                     return Ok(None);
                 };
 

--- a/src/send_command.rs
+++ b/src/send_command.rs
@@ -331,7 +331,7 @@ impl SendCommandState {
                 state: current_command,
                 event,
             } => {
-                // Command is not finshed yet
+                // Command is not finished yet
                 self.current_command = Some(current_command);
                 Ok(event)
             }
@@ -343,7 +343,7 @@ impl SendCommandState {
     }
 }
 
-/// A command that is queued but not sent yet.
+/// Queued (and not sent yet) command.
 #[derive(Debug)]
 struct QueuedCommand {
     handle: ClientFlowCommandHandle,
@@ -404,14 +404,14 @@ impl QueuedCommand {
     }
 }
 
-/// A command that is currently being sent.
+/// Currently being sent command.
 #[derive(Debug)]
 enum CurrentCommand {
-    /// The sending state of a regular command.
+    /// Sending state of regular command.
     Command(CommandState),
-    /// The sending state of a authenticate command.
+    /// Sending state of authenticate command.
     Authenticate(AuthenticateState),
-    /// The sending state of a idle command.
+    /// Sending state of idle command.
     Idle(IdleState),
 }
 
@@ -435,18 +435,18 @@ impl CurrentCommand {
     }
 }
 
-/// The updated command state after sending all bytes, see `finish_sending`.
+/// Updated command state after sending all bytes, see `finish_sending`.
 enum FinishSendingResult<S> {
-    // The command is not finished yet.
+    /// Command not finished yet.
     Uncompleted {
-        // The updated command state.
+        /// Updated command state.
         state: S,
-        // An event that needs to be returned by `progress`.
+        /// Event that needs to be returned by `progress`.
         event: Option<SendCommandEvent>,
     },
-    // The command was sent completely.
+    /// Command sent completely.
     Completed {
-        // An event that needs to be returned by `progress`.
+        /// Event that needs to be returned by `progress`.
         event: SendCommandEvent,
     },
 }
@@ -559,7 +559,7 @@ enum CommandActivity {
     /// Waiting until the server accepts the literal via continuation request or rejects it
     /// via status.
     WaitingForLiteralAccepted {
-        /// The literal that needs to be accepted by the server.
+        /// Literal that needs to be accepted by the server.
         limbo_literal: Vec<u8>,
     },
 }
@@ -702,7 +702,7 @@ enum IdleActivity {
     WaitingForIdleDoneSent,
 }
 
-// A command was sent.
+/// Command was sent.
 #[derive(Debug)]
 pub enum SendCommandEvent {
     Command {
@@ -720,25 +720,23 @@ pub enum SendCommandEvent {
     },
 }
 
-// A command was terminated via `maybe_terminate`.
+/// Command was terminated via `maybe_terminate`.
 pub enum SendCommandTermination {
-    // A command was terminated because its literal was rejected by the server.
+    /// Command was terminated because its literal was rejected by the server.
     LiteralRejected {
         handle: ClientFlowCommandHandle,
         command: Command<'static>,
     },
-    // An authenticate command was terminated because the server accepted it.
+    /// Authenticate command was accepted.
     AuthenticateAccepted {
         handle: ClientFlowCommandHandle,
         command_authenticate: CommandAuthenticate,
     },
-    // An authenticate command was terminated because the server rejected it.
+    /// Authenticate command was rejected.
     AuthenticateRejected {
         handle: ClientFlowCommandHandle,
         command_authenticate: CommandAuthenticate,
     },
-    // Ad idle command was terminated because the server rejected it.
-    IdleRejected {
-        handle: ClientFlowCommandHandle,
-    },
+    /// Idle command was rejected.
+    IdleRejected { handle: ClientFlowCommandHandle },
 }

--- a/src/send_command.rs
+++ b/src/send_command.rs
@@ -10,9 +10,12 @@ use imap_types::{
     command::{Command, CommandBody},
     core::{LiteralMode, Tag},
     extensions::idle::IdleDone,
+    response::{Status, StatusBody, StatusKind, Tagged},
 };
+use tracing::warn;
 
 use crate::{
+    client::ClientFlow,
     stream::{AnyStream, StreamError},
     types::CommandAuthenticate,
 };
@@ -22,12 +25,14 @@ pub struct SendCommandState<K: Copy> {
     command_codec: CommandCodec,
     authenticate_data_codec: AuthenticateDataCodec,
     idle_done_codec: IdleDoneCodec,
-    // The commands that should be send.
-    send_queue: VecDeque<SendCommandQueueEntry<K>>,
-    // State of the command that is currently being sent.
-    send_progress: Option<SendCommandProgress<K>>,
-    // Used for writing the current command to the stream.
-    // Should be empty if `send_progress` is `None`.
+    /// FIFO queue for commands that should be sent next.
+    queued_commands: VecDeque<QueuedCommand<K>>,
+    /// The command that is currently being sent.
+    current_command: Option<CurrentCommand<K>>,
+    /// Used for writing the current command to the stream.
+    /// Note that this buffer can be non-empty even if `current_command` is `None`
+    /// because commands can be aborted (see `maybe_terminate`) but partially sent
+    /// fragment must never be aborted.
     write_buffer: BytesMut,
 }
 
@@ -42,432 +47,681 @@ impl<K: Copy> SendCommandState<K> {
             command_codec,
             authenticate_data_codec,
             idle_done_codec,
-            send_queue: VecDeque::new(),
-            send_progress: None,
+            queued_commands: VecDeque::new(),
+            current_command: None,
             write_buffer,
         }
     }
 
     pub fn enqueue(&mut self, key: K, command: Command<'static>) {
-        let fragments = self.command_codec.encode(&command).collect();
-        let kind = match command.body {
-            CommandBody::Authenticate {
-                mechanism,
-                initial_response,
-            } => SendCommandKind::Authenticate {
-                command_authenticate: CommandAuthenticate {
-                    tag: command.tag,
-                    mechanism,
-                    initial_response,
-                },
-                started: false,
-            },
-            CommandBody::Idle => SendCommandKind::Idle {
-                tag: command.tag,
-                started: false,
-            },
-            body => SendCommandKind::Regular {
-                command: Command {
-                    tag: command.tag,
-                    body,
-                },
-            },
-        };
-        self.send_queue.push_back(SendCommandQueueEntry {
-            key,
-            kind,
-            fragments,
+        self.queued_commands
+            .push_back(QueuedCommand { key, command });
+    }
+
+    /// Terminates the current command depending on the received status.
+    pub fn maybe_remove(&mut self, status: &Status) -> Option<SendCommandTermination<K>> {
+        // TODO: Do we want more checks on the state? Was idle already accepted? Does the command even has a literal? etc.
+        // If we reach one of the return statements, the current command will be removed
+        let current_command = self.current_command.take()?;
+        self.current_command = Some(match current_command {
+            CurrentCommand::Command(state) => {
+                // Check if status matches the current command
+                if let Status::Tagged(Tagged {
+                    tag,
+                    body: StatusBody { kind, .. },
+                    ..
+                }) = status
+                {
+                    if *kind == StatusKind::Bad && tag == &state.command.tag {
+                        // Terminate command because literal was rejected
+                        return Some(SendCommandTermination::LiteralRejected {
+                            key: state.key,
+                            command: state.command,
+                        });
+                    }
+                }
+
+                CurrentCommand::Command(state)
+            }
+            CurrentCommand::Authenticate(state) => {
+                // Check if status matches the current authenticate command
+                if let Status::Tagged(Tagged {
+                    tag,
+                    body: StatusBody { kind, .. },
+                    ..
+                }) = status
+                {
+                    if tag == &state.command_authenticate.tag {
+                        match kind {
+                            StatusKind::Ok => {
+                                // Terminate authenticate command because it was accepted
+                                return Some(SendCommandTermination::AuthenticateAccepted {
+                                    key: state.key,
+                                    command_authenticate: state.command_authenticate,
+                                });
+                            }
+                            StatusKind::No | StatusKind::Bad => {
+                                // Terminate authenticate command because it was rejected
+                                return Some(SendCommandTermination::AuthenticateRejected {
+                                    key: state.key,
+                                    command_authenticate: state.command_authenticate,
+                                });
+                            }
+                        };
+                    }
+                }
+
+                CurrentCommand::Authenticate(state)
+            }
+            CurrentCommand::Idle(state) => {
+                // Check if status matches the current idle command
+                if let Status::Tagged(Tagged {
+                    tag,
+                    body: StatusBody { kind, .. },
+                    ..
+                }) = status
+                {
+                    if tag == &state.tag {
+                        if matches!(kind, StatusKind::Ok | StatusKind::Bad) {
+                            warn!(got=?status, "Expected command continuation request response or NO command completion result");
+                            warn!("Interpreting as IDLE rejected");
+                        }
+
+                        // Terminate idle command because it was rejected
+                        return Some(SendCommandTermination::IdleRejected { key: state.key });
+                    }
+                }
+
+                CurrentCommand::Idle(state)
+            }
         });
+
+        None
     }
 
-    pub fn command_in_progress(&self) -> Option<&SendCommandKind> {
-        self.send_progress.as_ref().map(|x| &x.kind)
-    }
-
-    pub fn remove_command_in_progress(&mut self) -> Option<(K, SendCommandKind)> {
-        self.write_buffer.clear();
-        self.send_progress
-            .take()
-            .map(|progress| (progress.key, progress.kind))
-    }
-
-    pub fn continue_literal(&mut self) -> bool {
-        let Some(write_progress) = self.send_progress.as_mut() else {
+    /// Handles the received continuation request for a literal.
+    pub fn literal_continue(&mut self) -> bool {
+        // Check whether in correct state
+        let Some(current_command) = self.current_command.take() else {
             return false;
         };
-        let Some(literal_progress) = write_progress.blocked_reason.as_mut() else {
+        let CurrentCommand::Command(state) = current_command else {
+            self.current_command = Some(current_command);
             return false;
         };
-        let SendCommandBlockedReason::WaitForLiteralAck {
-            received_continue, ..
-        } = literal_progress
-        else {
+        let CommandActivity::WaitingForLiteralAccepted { limbo_literal } = state.activity else {
+            self.current_command = Some(CurrentCommand::Command(state));
             return false;
         };
-        if *received_continue {
-            return false;
-        }
 
-        *received_continue = true;
+        // Change state
+        self.current_command = Some(CurrentCommand::Command(CommandState {
+            activity: CommandActivity::PushingFragments {
+                accepted_literal: Some(limbo_literal),
+            },
+            ..state
+        }));
 
         true
     }
 
-    pub fn continue_authenticate(&mut self) -> Option<&K> {
-        let write_progress = self.send_progress.as_mut()?;
-        let literal_progress = write_progress.blocked_reason.as_mut()?;
-        let SendCommandBlockedReason::WaitForAuthenticateData {
-            received_continue, ..
-        } = literal_progress
-        else {
+    /// Handles the received continuation request for an authenticate data.
+    pub fn authenticate_continue(&mut self) -> Option<K> {
+        // Check whether in correct state
+        let Some(current_command) = self.current_command.take() else {
             return None;
         };
-        if *received_continue {
+        let CurrentCommand::Authenticate(state) = current_command else {
+            self.current_command = Some(current_command);
             return None;
-        }
+        };
+        let AuthenticateActivity::WaitingForAuthenticateResponse = state.activity else {
+            self.current_command = Some(CurrentCommand::Authenticate(state));
+            return None;
+        };
 
-        *received_continue = true;
+        // Change state
+        self.current_command = Some(CurrentCommand::Authenticate(AuthenticateState {
+            activity: AuthenticateActivity::WaitingForAuthenticateDataSet,
+            ..state
+        }));
 
-        Some(&write_progress.key)
+        Some(state.key)
     }
 
-    pub fn continue_authenticate_with_data(
+    /// Takes the requested authenticate data and sends it to the server.
+    pub fn set_authenticate_data(
         &mut self,
         authenticate_data: AuthenticateData,
-    ) -> Result<&K, AuthenticateData> {
-        let Some(write_progress) = self.send_progress.as_mut() else {
+    ) -> Result<K, AuthenticateData> {
+        // Check whether in correct state
+        let Some(current_command) = self.current_command.take() else {
             return Err(authenticate_data);
         };
-        let Some(literal_progress) = write_progress.blocked_reason.as_mut() else {
+        let CurrentCommand::Authenticate(state) = current_command else {
+            self.current_command = Some(current_command);
             return Err(authenticate_data);
         };
-        let SendCommandBlockedReason::WaitForAuthenticateData {
-            received_continue,
-            authenticate_data: current_authenticate_data,
-        } = literal_progress
+        let AuthenticateActivity::WaitingForAuthenticateDataSet = state.activity else {
+            self.current_command = Some(CurrentCommand::Authenticate(state));
+            return Err(authenticate_data);
+        };
+
+        // Encode authenticate data
+        let mut fragments = self.authenticate_data_codec.encode(&authenticate_data);
+        // Authenticate data is a single line by definition
+        let Some(Fragment::Line {
+            data: authenticate_data,
+        }) = fragments.next()
         else {
-            return Err(authenticate_data);
+            unreachable!()
         };
-        if !*received_continue {
-            return Err(authenticate_data);
-        }
-        if current_authenticate_data.is_some() {
-            return Err(authenticate_data);
-        }
+        assert!(fragments.next().is_none());
 
-        *current_authenticate_data = Some(authenticate_data);
+        // Change state
+        self.current_command = Some(CurrentCommand::Authenticate(AuthenticateState {
+            activity: AuthenticateActivity::PushingAuthenticateData { authenticate_data },
+            ..state
+        }));
 
-        Ok(&write_progress.key)
+        Ok(state.key)
     }
 
-    pub fn continue_idle(&mut self) -> Option<&K> {
-        let write_progress = self.send_progress.as_mut()?;
-        let literal_progress = write_progress.blocked_reason.as_mut()?;
-        let SendCommandBlockedReason::Idle {
-            received_continue, ..
-        } = literal_progress
-        else {
+    /// Handles the received continuation request for the idle done.
+    pub fn idle_continue(&mut self) -> Option<K> {
+        // Check whether in correct state
+        let Some(current_command) = self.current_command.take() else {
             return None;
         };
-        if *received_continue {
+        let CurrentCommand::Idle(state) = current_command else {
+            self.current_command = Some(current_command);
             return None;
-        }
+        };
+        let IdleActivity::WaitingForIdleResponse = state.activity else {
+            self.current_command = Some(CurrentCommand::Idle(state));
+            return None;
+        };
 
-        *received_continue = true;
+        // Change state
+        self.current_command = Some(CurrentCommand::Idle(IdleState {
+            activity: IdleActivity::WaitingForIdleDoneSet,
+            ..state
+        }));
 
-        Some(&write_progress.key)
+        Some(state.key)
     }
 
-    pub fn idle_done(&mut self) -> Option<&K> {
-        let Some(write_progress) = self.send_progress.as_mut() else {
+    /// Sends the requested idle done to the server.
+    pub fn set_idle_done(&mut self) -> Option<K> {
+        // Check whether in correct state
+        let Some(current_command) = self.current_command.take() else {
             return None;
         };
-        let Some(literal_progress) = write_progress.blocked_reason.as_mut() else {
+        let CurrentCommand::Idle(state) = current_command else {
+            self.current_command = Some(current_command);
             return None;
         };
-        let SendCommandBlockedReason::Idle {
-            received_continue,
-            idle_done: current_idle_done,
-        } = literal_progress
+        let IdleActivity::WaitingForIdleDoneSet = state.activity else {
+            self.current_command = Some(CurrentCommand::Idle(state));
+            return None;
+        };
+
+        // Encode idle done
+        let mut fragments = self.idle_done_codec.encode(&IdleDone);
+        // Idle done is a single line by defintion
+        let Some(Fragment::Line {
+            data: idle_done, ..
+        }) = fragments.next()
         else {
-            return None;
+            unreachable!()
         };
-        if !*received_continue {
-            return None;
-        }
-        if current_idle_done.is_some() {
-            return None;
-        }
+        assert!(fragments.next().is_none());
 
-        *current_idle_done = Some(IdleDone);
+        // Change state
+        let key = state.key;
+        self.current_command = Some(CurrentCommand::Idle(IdleState {
+            activity: IdleActivity::PushingIdleDone { idle_done },
+            ..state
+        }));
 
-        Some(&write_progress.key)
+        Some(key)
     }
 
     pub async fn progress(
         &mut self,
         stream: &mut AnyStream,
     ) -> Result<Option<SendCommandEvent<K>>, StreamError> {
-        let progress = match self.send_progress.take() {
-            Some(progress) => {
-                // We are currently sending a command to the server. This sending process was
-                // previously aborted for one of two reasons: Either we needed to wait for a
-                // `Continue` from the server or the `Future` was dropped while sending.
-                progress
+        let current_command = match self.current_command.take() {
+            Some(current_command) => {
+                // We are currently sending a command but the sending process was aborted for one
+                // of these reasons:
+                // - The future was cancelled
+                // - The server must send a continuation request or a status
+                // - The client flow user must provide more data
+                // Continue the sending process.
+                current_command
             }
             None => {
-                let Some(entry) = self.send_queue.pop_front() else {
+                let Some(queued_command) = self.queued_commands.pop_front() else {
                     // There is currently no command that needs to be sent
                     return Ok(None);
                 };
 
-                // Start sending the next command
-                SendCommandProgress {
-                    key: entry.key,
-                    kind: entry.kind,
-                    blocked_reason: None,
-                    next_fragments: entry.fragments,
-                }
-            }
-        };
-        let progress = self.send_progress.insert(progress);
-
-        // Handle the outstanding literal first if there is one
-        if let Some(suspended_reason) = progress.blocked_reason.take() {
-            match suspended_reason {
-                SendCommandBlockedReason::WaitForLiteralAck {
-                    data,
-                    received_continue,
-                } => {
-                    if received_continue {
-                        // We received a `Continue` from the server, we can send the literal now
-                        self.write_buffer.extend(data);
-                    } else {
-                        // Delay this literal because we still wait for the `Continue` from the server
-                        progress.blocked_reason =
-                            Some(SendCommandBlockedReason::WaitForLiteralAck {
-                                data,
-                                received_continue,
-                            });
-
-                        // Make sure that the line before the literal is sent completely to the server
-                        stream.write_all(&mut self.write_buffer).await?;
-
-                        return Ok(None);
-                    }
-                }
-                SendCommandBlockedReason::WaitForAuthenticateData {
-                    received_continue,
-                    authenticate_data,
-                } => {
-                    match authenticate_data {
-                        Some(authenticate_data) => {
-                            // The data can only be set after receiving a continue from server
-                            assert!(received_continue);
-
-                            // We received a `Continue` from the server and the auth data from the
-                            // client-flow user. We can send the auth data now.
-                            progress
-                                .next_fragments
-                                .extend(self.authenticate_data_codec.encode(&authenticate_data))
-                        }
-                        None => {
-                            // Delay this because we still wait for the client flow user to call
-                            // `authenticate_continue`.
-                            progress.blocked_reason =
-                                Some(SendCommandBlockedReason::WaitForAuthenticateData {
-                                    received_continue,
-                                    authenticate_data,
-                                });
-
-                            return Ok(None);
-                        }
-                    }
-                }
-                SendCommandBlockedReason::Idle {
-                    received_continue,
-                    idle_done,
-                } => {
-                    match idle_done {
-                        Some(done) => {
-                            // The `IdleDone` can only be set after receiving a `Continue`
-                            // from server
-                            assert!(received_continue);
-
-                            // We received a `Continue` from the server and the `IdleDone`
-                            // from the client-flow user. We can send the `IdleDone` now.
-                            progress
-                                .next_fragments
-                                .extend(self.idle_done_codec.encode(&done))
-                        }
-                        None => {
-                            // Delay this because we still wait for the client flow user to call
-                            // `idle_done`.
-                            progress.blocked_reason = Some(SendCommandBlockedReason::Idle {
-                                received_continue,
-                                idle_done,
-                            });
-
-                            return Ok(None);
-                        }
-                    }
-                }
-            }
-        }
-
-        // Handle the outstanding lines or literals
-        let need_continue = loop {
-            if let Some(fragment) = progress.next_fragments.pop_front() {
-                match fragment {
-                    Fragment::Line { data } => self.write_buffer.extend(data),
-                    Fragment::Literal { data, mode } => match mode {
-                        LiteralMode::Sync => {
-                            // We need to wait for a command continuation request response from the server
-                            progress.blocked_reason =
-                                Some(SendCommandBlockedReason::WaitForLiteralAck {
-                                    data,
-                                    received_continue: false,
-                                });
-                            break true;
-                        }
-                        LiteralMode::NonSync => self.write_buffer.extend(data),
-                    },
-                }
-            } else {
-                break false;
+                queued_command.start(&self.command_codec)
             }
         };
 
-        // Send the bytes of the command to the server
+        // Push as many bytes of the command as possible to the buffer
+        let current_command = current_command.push_to_buffer(&mut self.write_buffer);
+
+        // Store the current command to ensure cancellation safety
+        self.current_command = Some(current_command);
+
+        // Send all bytes of current command
         stream.write_all(&mut self.write_buffer).await?;
 
-        if need_continue {
-            Ok(None)
-        } else {
-            let Some(progress) = self.send_progress.take() else {
-                return Ok(None);
-            };
+        // Restore the current command, can't fail because we set it to `Some` above
+        let current_command = self.current_command.take().unwrap();
 
-            match progress.kind {
-                SendCommandKind::Regular { command } => {
-                    // Command was sent completely
-                    Ok(Some(SendCommandEvent::CommandSent {
-                        key: progress.key,
-                        command,
-                    }))
-                }
-                SendCommandKind::Authenticate {
-                    command_authenticate,
-                    started: was_started,
-                } => {
-                    // Authenticate is only treated as completed after receiving a "OK" from server
-                    let progress = self.send_progress.insert(SendCommandProgress {
-                        kind: SendCommandKind::Authenticate {
-                            command_authenticate,
-                            started: true,
-                        },
-                        blocked_reason: Some(SendCommandBlockedReason::WaitForAuthenticateData {
-                            received_continue: false,
-                            authenticate_data: None,
-                        }),
-                        ..progress
-                    });
-
-                    if was_started {
-                        // Command was already sent before
-                        Ok(None)
-                    } else {
-                        // Command was sent just now
-                        Ok(Some(SendCommandEvent::CommandAuthenticateStarted {
-                            key: progress.key,
-                        }))
-                    }
-                }
-                SendCommandKind::Idle {
-                    tag,
-                    started: was_started,
-                } => {
-                    if was_started {
-                        Ok(Some(SendCommandEvent::IdleTerminated { key: progress.key }))
-                    } else {
-                        let progress = self.send_progress.insert(SendCommandProgress {
-                            kind: SendCommandKind::Idle { tag, started: true },
-                            blocked_reason: Some(SendCommandBlockedReason::Idle {
-                                received_continue: false,
-                                idle_done: None,
-                            }),
-                            ..progress
-                        });
-
-                        Ok(Some(SendCommandEvent::IdleStarted { key: progress.key }))
-                    }
-                }
+        // Inform the state of the current command that all bytes were sent
+        match current_command.finish_sending() {
+            FinishSendingResult::Uncompleted {
+                state: current_command,
+                event,
+            } => {
+                // Command is not finshed yet
+                self.current_command = Some(current_command);
+                Ok(event)
+            }
+            FinishSendingResult::Completed { event } => {
+                // Command was sent completely
+                Ok(Some(event))
             }
         }
     }
 }
 
-pub enum SendCommandEvent<K> {
-    CommandSent { key: K, command: Command<'static> },
-    CommandAuthenticateStarted { key: K },
-    IdleStarted { key: K },
-    IdleTerminated { key: K },
+/// A command that is queued but not sent yet.
+#[derive(Debug)]
+struct QueuedCommand<K: Copy> {
+    key: K,
+    command: Command<'static>,
 }
 
-// TODO(#105)
+impl<K: Copy> QueuedCommand<K> {
+    /// Start the sending process for this command.
+    fn start(self, codec: &CommandCodec) -> CurrentCommand<K> {
+        let key = self.key;
+        let command = self.command;
+        let mut fragments = codec.encode(&command);
+        let tag = command.tag;
+
+        match command.body {
+            CommandBody::Authenticate {
+                mechanism,
+                initial_response,
+            } => {
+                // The authenticate command is a single line by definition
+                let Some(Fragment::Line { data: authenticate }) = fragments.next() else {
+                    unreachable!()
+                };
+                assert!(fragments.next().is_none());
+
+                CurrentCommand::Authenticate(AuthenticateState {
+                    key,
+                    command_authenticate: CommandAuthenticate {
+                        tag,
+                        mechanism,
+                        initial_response,
+                    },
+                    activity: AuthenticateActivity::PushingAuthenticate { authenticate },
+                })
+            }
+            CommandBody::Idle => {
+                // The idle command is a single line by definition
+                let Some(Fragment::Line { data: idle }) = fragments.next() else {
+                    unreachable!()
+                };
+                assert!(fragments.next().is_none());
+
+                CurrentCommand::Idle(IdleState {
+                    key,
+                    tag,
+                    activity: IdleActivity::PushingIdle { idle },
+                })
+            }
+            body => CurrentCommand::Command(CommandState {
+                key,
+                command: Command { tag, body },
+                fragments: fragments.collect(),
+                activity: CommandActivity::PushingFragments {
+                    accepted_literal: None,
+                },
+            }),
+        }
+    }
+}
+
+/// A command that is currently being sent.
 #[derive(Debug)]
-pub enum SendCommandKind {
-    Regular {
+enum CurrentCommand<K: Copy> {
+    /// The sending state of a regular command.
+    Command(CommandState<K>),
+    /// The sending state of a authenticate command.
+    Authenticate(AuthenticateState<K>),
+    /// The sending state of a idle command.
+    Idle(IdleState<K>),
+}
+
+impl<K: Copy> CurrentCommand<K> {
+    /// Pushes as many bytes as possible from the command to the buffer.
+    fn push_to_buffer(self, write_buffer: &mut BytesMut) -> Self {
+        match self {
+            Self::Command(state) => Self::Command(state.push_to_buffer(write_buffer)),
+            Self::Authenticate(state) => Self::Authenticate(state.push_to_buffer(write_buffer)),
+            Self::Idle(state) => Self::Idle(state.push_to_buffer(write_buffer)),
+        }
+    }
+
+    /// Updates the state after all bytes were sent.
+    fn finish_sending(self) -> FinishSendingResult<K, Self> {
+        match self {
+            Self::Command(state) => state.finish_sending().map_state(Self::Command),
+            Self::Authenticate(state) => state.finish_sending().map_state(Self::Authenticate),
+            Self::Idle(state) => state.finish_sending().map_state(Self::Idle),
+        }
+    }
+}
+
+/// The updated command state after sending all bytes, see `finish_sending`.
+enum FinishSendingResult<K, S> {
+    // The command is not finished yet.
+    Uncompleted {
+        // The updated command state.
+        state: S,
+        // An event that needs to be returned by `progress`.
+        event: Option<SendCommandEvent<K>>,
+    },
+    // The command was sent completely.
+    Completed {
+        // An event that needs to be returned by `progress`.
+        event: SendCommandEvent<K>,
+    },
+}
+
+impl<K, S> FinishSendingResult<K, S> {
+    fn map_state<T>(self, f: impl Fn(S) -> T) -> FinishSendingResult<K, T> {
+        match self {
+            FinishSendingResult::Uncompleted { state, event } => FinishSendingResult::Uncompleted {
+                state: f(state),
+                event,
+            },
+            FinishSendingResult::Completed { event } => FinishSendingResult::Completed { event },
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CommandState<K> {
+    key: K,
+    command: Command<'static>,
+    /// The outstanding command fragments that needs to be sent.
+    fragments: VecDeque<Fragment>,
+    activity: CommandActivity,
+}
+
+impl<K> CommandState<K> {
+    fn push_to_buffer(self, write_buffer: &mut BytesMut) -> Self {
+        let mut fragments = self.fragments;
+        let activity = match self.activity {
+            CommandActivity::PushingFragments { accepted_literal } => {
+                // First push the accepted literal if available
+                if let Some(data) = accepted_literal {
+                    write_buffer.extend(data);
+                }
+
+                // Push as many fragments as possible
+                let limbo_literal = loop {
+                    match fragments.pop_front() {
+                        Some(
+                            Fragment::Line { data }
+                            | Fragment::Literal {
+                                data,
+                                mode: LiteralMode::NonSync,
+                            },
+                        ) => {
+                            write_buffer.extend(data);
+                        }
+                        Some(Fragment::Literal {
+                            data,
+                            mode: LiteralMode::Sync,
+                        }) => {
+                            // Stop pushing fragments because a literal needs to be accepted
+                            // by the server
+                            break Some(data);
+                        }
+                        None => break None,
+                    };
+                };
+
+                // Done with pushing
+                CommandActivity::WaitingForFragmentsSent { limbo_literal }
+            }
+            activity => activity,
+        };
+
+        Self {
+            fragments,
+            activity,
+            ..self
+        }
+    }
+
+    fn finish_sending(self) -> FinishSendingResult<K, Self> {
+        match self.activity {
+            CommandActivity::WaitingForFragmentsSent { limbo_literal } => match limbo_literal {
+                Some(limbo_literal) => FinishSendingResult::Uncompleted {
+                    state: Self {
+                        activity: CommandActivity::WaitingForLiteralAccepted { limbo_literal },
+                        ..self
+                    },
+                    event: None,
+                },
+                None => FinishSendingResult::Completed {
+                    event: SendCommandEvent::Command {
+                        key: self.key,
+                        command: self.command,
+                    },
+                },
+            },
+            activity => FinishSendingResult::Uncompleted {
+                state: Self { activity, ..self },
+                event: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum CommandActivity {
+    /// Pushing fragments to the write buffer.
+    PushingFragments {
+        /// A literal that was accepted by the server and needs to be sent before the fragments.
+        accepted_literal: Option<Vec<u8>>,
+    },
+    /// Waiting until the pushed fragments are sent.
+    WaitingForFragmentsSent {
+        /// A literal that needs to be accepted by the server after the pushed fragments are sent.
+        limbo_literal: Option<Vec<u8>>,
+    },
+    /// Waiting until the server accepts the literal via continuation request or rejects it
+    /// via status.
+    WaitingForLiteralAccepted {
+        /// The literal that needs to be accepted by the server.
+        limbo_literal: Vec<u8>,
+    },
+}
+
+#[derive(Debug)]
+struct AuthenticateState<K: Copy> {
+    key: K,
+    command_authenticate: CommandAuthenticate,
+    activity: AuthenticateActivity,
+}
+
+impl<K: Copy> AuthenticateState<K> {
+    fn push_to_buffer(self, write_buffer: &mut BytesMut) -> Self {
+        let activity = match self.activity {
+            AuthenticateActivity::PushingAuthenticate { authenticate } => {
+                write_buffer.extend(authenticate);
+                AuthenticateActivity::WaitingForAuthenticateSent
+            }
+            AuthenticateActivity::PushingAuthenticateData { authenticate_data } => {
+                write_buffer.extend(authenticate_data);
+                AuthenticateActivity::WaitingForAuthenticateDataSent
+            }
+            activity => activity,
+        };
+
+        Self { activity, ..self }
+    }
+
+    fn finish_sending(self) -> FinishSendingResult<K, Self> {
+        match self.activity {
+            AuthenticateActivity::WaitingForAuthenticateSent => FinishSendingResult::Uncompleted {
+                state: Self {
+                    activity: AuthenticateActivity::WaitingForAuthenticateResponse,
+                    ..self
+                },
+                event: Some(SendCommandEvent::CommandAuthenticate { key: self.key }),
+            },
+            AuthenticateActivity::WaitingForAuthenticateDataSent => {
+                FinishSendingResult::Uncompleted {
+                    state: Self {
+                        activity: AuthenticateActivity::WaitingForAuthenticateResponse,
+                        ..self
+                    },
+                    event: None,
+                }
+            }
+            activity => FinishSendingResult::Uncompleted {
+                state: Self { activity, ..self },
+                event: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AuthenticateActivity {
+    /// Pushing the authenticate command to the write buffer.
+    PushingAuthenticate { authenticate: Vec<u8> },
+    /// Waiting until the pushed authenticate command is sent.
+    WaitingForAuthenticateSent,
+    /// Waiting until the server requests more authenticate data via continuation request or
+    /// accepts/rejects the authenticate command via status.
+    WaitingForAuthenticateResponse,
+    /// Waiting until the client flow user provides the authenticate data.
+    ///
+    /// Specifically, [`ClientFlow::set_authenticate_data`].
+    WaitingForAuthenticateDataSet,
+    /// Pushing the authenticate data to the write buffer.
+    PushingAuthenticateData { authenticate_data: Vec<u8> },
+    /// Waiting until the pushed authenticate data is sent.
+    WaitingForAuthenticateDataSent,
+}
+
+#[derive(Debug)]
+struct IdleState<K: Copy> {
+    key: K,
+    tag: Tag<'static>,
+    activity: IdleActivity,
+}
+
+impl<K: Copy> IdleState<K> {
+    fn push_to_buffer(self, write_buffer: &mut BytesMut) -> Self {
+        let activity = match self.activity {
+            IdleActivity::PushingIdle { idle } => {
+                write_buffer.extend(idle);
+                IdleActivity::WaitingForIdleSent
+            }
+            IdleActivity::PushingIdleDone { idle_done } => {
+                write_buffer.extend(idle_done);
+                IdleActivity::WaitingForIdleDoneSent
+            }
+            activity => activity,
+        };
+
+        Self { activity, ..self }
+    }
+
+    fn finish_sending(self) -> FinishSendingResult<K, Self> {
+        match self.activity {
+            IdleActivity::WaitingForIdleSent => FinishSendingResult::Uncompleted {
+                state: Self {
+                    activity: IdleActivity::WaitingForIdleResponse,
+                    ..self
+                },
+                event: Some(SendCommandEvent::CommandIdle { key: self.key }),
+            },
+            IdleActivity::WaitingForIdleDoneSent => FinishSendingResult::Completed {
+                event: SendCommandEvent::IdleDone { key: self.key },
+            },
+            activity => FinishSendingResult::Uncompleted {
+                state: Self { activity, ..self },
+                event: None,
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum IdleActivity {
+    /// Pushing the idle command to the write buffer.
+    PushingIdle { idle: Vec<u8> },
+    /// Waiting until the pushed idle command is sent.
+    WaitingForIdleSent,
+    /// Waiting until the server accepts the idle command via continuation request or rejects it
+    /// via status.
+    WaitingForIdleResponse,
+    /// Waiting until the client flow user triggers idle done.
+    ///
+    /// Specifically, [`ClientFlow::set_idle_done`].
+    WaitingForIdleDoneSet,
+    /// Pushing the idle done to the write buffer.
+    PushingIdleDone { idle_done: Vec<u8> },
+    /// Waiting until the pushed idle done is sent.
+    WaitingForIdleDoneSent,
+}
+
+// A command was sent.
+#[derive(Debug)]
+pub enum SendCommandEvent<K> {
+    Command { key: K, command: Command<'static> },
+    CommandAuthenticate { key: K },
+    CommandIdle { key: K },
+    IdleDone { key: K },
+}
+
+// A command was terminated via `maybe_terminate`.
+pub enum SendCommandTermination<K> {
+    // A command was terminated because its literal was rejected by the server.
+    LiteralRejected {
+        key: K,
         command: Command<'static>,
     },
-    Authenticate {
+    // An authenticate command was terminated because the server accepted it.
+    AuthenticateAccepted {
+        key: K,
         command_authenticate: CommandAuthenticate,
-        started: bool,
     },
-    Idle {
-        tag: Tag<'static>,
-        started: bool,
+    // An authenticate command was terminated because the server rejected it.
+    AuthenticateRejected {
+        key: K,
+        command_authenticate: CommandAuthenticate,
     },
-}
-
-#[derive(Debug)]
-struct SendCommandQueueEntry<K> {
-    key: K,
-    kind: SendCommandKind,
-    fragments: VecDeque<Fragment>,
-}
-
-#[derive(Debug)]
-struct SendCommandProgress<K> {
-    key: K,
-    kind: SendCommandKind,
-    // If defined we need to wait for something before we can send `next_fragments`.
-    blocked_reason: Option<SendCommandBlockedReason>,
-    // The fragments that need to be sent.
-    next_fragments: VecDeque<Fragment>,
-}
-
-#[derive(Debug)]
-enum SendCommandBlockedReason {
-    WaitForLiteralAck {
-        // The bytes of the literal.
-        data: Vec<u8>,
-        // Was the literal already acknowledged by a `Continue` from the server?
-        received_continue: bool,
-    },
-    // TODO(#105)
-    WaitForAuthenticateData {
-        // Was the authenticate data already requested by the server?
-        received_continue: bool,
-        // The authenticate data provided by the client flow user.
-        // Should only be set when requested by the server.
-        authenticate_data: Option<AuthenticateData>,
-    },
-    Idle {
-        // Has the server already sent a `Continue`?
-        received_continue: bool,
-        // The `IdleDone` provided by the client flow user.
-        // Should only be set after a `Continue` was received from the server.
-        idle_done: Option<IdleDone>,
+    // Ad idle command was terminated because the server rejected it.
+    IdleRejected {
+        key: K,
     },
 }

--- a/src/send_response.rs
+++ b/src/send_response.rs
@@ -62,7 +62,7 @@ where
                 assert!(self.write_buffer.is_empty());
 
                 let Some(queued_response) = self.queued_responses.pop_front() else {
-                    // There is currently no response that need to be sent
+                    // There is currently no response that needs to be sent
                     return Ok(None);
                 };
 

--- a/src/send_response.rs
+++ b/src/send_response.rs
@@ -89,7 +89,7 @@ where
     }
 }
 
-// A response that is queued but not sent yet.
+/// A response that is queued but not sent yet.
 #[derive(Debug)]
 struct QueuedResponse<C: Encoder>
 where
@@ -123,7 +123,7 @@ where
     }
 }
 
-// A response that is currently being sent.
+/// A response that is currently being sent.
 #[derive(Debug)]
 struct CurrentResponse<C: Encoder>
 where
@@ -133,7 +133,7 @@ where
     response: C::Message<'static>,
 }
 
-// A response was sent.
+/// A response was sent.
 pub struct SendResponseEvent<C: Encoder> {
     pub handle: Option<ServerFlowResponseHandle>,
     pub response: C::Message<'static>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,7 @@
+//! Types that extend `imap-types`.
+//!
+//! TODO: Do we really need this?
+
 use std::borrow::Cow;
 
 use imap_types::{


### PR DESCRIPTION
The module `send_command` contains probably the most complicated code in this repository. I tried to refactor it and I think it's better now, though not perfect.

Highlights:
- Regular commands, authenticate and idle are handled completely separately without much code duplication
- Better state machines
- `SendCommandState::progress` is short and readable
- I was able to move `ClientFlow::maybe_finish_command` to the `send_command` module and it looks much simpler now.

I tested it by using our proxy and it seems to work.