### PR TITLE
chore: Migrate to newer `imap-types`

### DIFF
--- a/proxy/src/util.rs
+++ b/proxy/src/util.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::BufReader, path::Path};
 
 use imap_types::{
     auth::AuthMechanism,
-    core::NonEmptyVec,
+    core::Vec1,
     response::{
         Bye, Capability, Code, CommandContinuationRequest, CommandContinuationRequestBasic, Data,
         Greeting, Status, StatusBody, Tagged,
@@ -97,7 +97,7 @@ pub fn filter_capabilities_in_continuation(continuation: &mut CommandContinuatio
 }
 
 // Remove unsupported capabilities in a capability list.
-fn filter_capabilities(capabilities: NonEmptyVec<Capability>) -> NonEmptyVec<Capability> {
+fn filter_capabilities(capabilities: Vec1<Capability>) -> Vec1<Capability> {
     let filtered: Vec<_> = capabilities
         .into_iter()
         .filter(|capability| match capability {
@@ -114,7 +114,7 @@ fn filter_capabilities(capabilities: NonEmptyVec<Capability>) -> NonEmptyVec<Cap
         })
         .collect();
 
-    NonEmptyVec::try_from(filtered).unwrap_or(NonEmptyVec::from(Capability::Imap4Rev1))
+    Vec1::try_from(filtered).unwrap_or(Vec1::from(Capability::Imap4Rev1))
 }
 
 fn is_auth_mechanism_proxyable(auth_mechanism: &AuthMechanism) -> bool {

--- a/tasks/src/tasks.rs
+++ b/tasks/src/tasks.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use imap_types::{
     auth::{AuthMechanism, AuthenticateData},
     command::CommandBody,
-    core::NonEmptyVec,
+    core::Vec1,
     response::{Bye, Capability, CommandContinuationRequest, Data, StatusBody, StatusKind},
     secret::Secret,
 };
@@ -17,11 +17,11 @@ use crate::Task;
 #[derive(Default)]
 pub struct CapabilityTask {
     /// We use this as scratch space.
-    capabilities: Option<NonEmptyVec<Capability<'static>>>,
+    capabilities: Option<Vec1<Capability<'static>>>,
 }
 
 impl Task for CapabilityTask {
-    type Output = Result<NonEmptyVec<Capability<'static>>, &'static str>;
+    type Output = Result<Vec1<Capability<'static>>, &'static str>;
 
     fn command_body(&self) -> CommandBody<'static> {
         CommandBody::Capability


### PR DESCRIPTION
Fixes a breaking change in `imap-types`. The type `NonEmptyVec` was replaced with `Vec1`.