### PR TITLE
refactor: Make option types more backwards compatible

### DIFF
--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -194,7 +194,7 @@ impl Proxy<ConnectedState> {
     pub async fn start_conversation(self) {
         let (mut proxy_to_server, mut greeting) = {
             // TODO: Read options from config
-            let options = ClientFlowOptions { crlf_relaxed: true };
+            let options = ClientFlowOptions::default();
 
             let result = ClientFlow::receive_greeting(self.state.proxy_to_server, options).await;
 
@@ -212,11 +212,9 @@ impl Proxy<ConnectedState> {
 
         let (mut client_to_proxy, greeting) = {
             // TODO: Read options from config
-            let options = ServerFlowOptions {
-                literal_accept_text: Text::try_from(LITERAL_ACCEPT_TEXT).unwrap(),
-                literal_reject_text: Text::try_from(LITERAL_REJECT_TEXT).unwrap(),
-                ..Default::default()
-            };
+            let mut options = ServerFlowOptions::default();
+            options.literal_accept_text = Text::try_from(LITERAL_ACCEPT_TEXT).unwrap();
+            options.literal_reject_text = Text::try_from(LITERAL_REJECT_TEXT).unwrap();
 
             let result =
                 ServerFlow::send_greeting(self.state.client_to_proxy, options, greeting).await;

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,8 @@ use crate::{
 static HANDLE_GENERATOR_GENERATOR: HandleGeneratorGenerator<ClientFlowCommandHandle> =
     HandleGeneratorGenerator::new();
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct ClientFlowOptions {
     pub crlf_relaxed: bool,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -26,6 +26,7 @@ static HANDLE_GENERATOR_GENERATOR: HandleGeneratorGenerator<ServerFlowResponseHa
     HandleGeneratorGenerator::new();
 
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub struct ServerFlowOptions {
     pub crlf_relaxed: bool,
     pub max_literal_size: u32,


### PR DESCRIPTION
We have two option types: `ServerFlowOptions` and `ClientFlowOptions`. We might want to add additional fields to them in the future. It would be nice if we were able to do that without a breaking change. So I propose:

- Let's make them `#[non_exhaustive]`. This allows us to add fields.
- Let's make `ClientFlowOptions` non-`Copy`. This allos us to add non-`Copy` fields.

The `Codec` types in `imap-codec` already do this.

Caveat: To my surprise the `..` notation does not work with `#[non_exhaustive]` (maybe in the future, see https://github.com/rust-lang/rust/issues/70564#issuecomment-1409770088). So this doesn't work:
```rust
let options = ServerFlowOptions {
  crlf_relaxed: false,
  ..ServerFlowOptions::default()
}
```
Instead you need to write this:
```rust
let mut options = ServerFlowOptions::default();
options.crlf_relaxed = false;
```
But I'm willing to accept this.