### PR TITLE
chore: Migrate to newer `imap-types`

### DIFF
--- a/examples/client_authenticate.rs
+++ b/examples/client_authenticate.rs
@@ -7,7 +7,6 @@ use imap_flow::{
 use imap_types::{
     auth::{AuthMechanism, AuthenticateData},
     command::{Command, CommandBody},
-    secret::Secret,
 };
 use tag_generator::TagGenerator;
 use tokio::net::TcpStream;
@@ -30,8 +29,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     });
 
     let mut authenticate_data = VecDeque::from([
-        AuthenticateData::Continue(Secret::new(b"alice".to_vec())),
-        AuthenticateData::Continue(Secret::new(b"password".to_vec())),
+        AuthenticateData::r#continue(b"alice".to_vec()),
+        AuthenticateData::r#continue(b"password".to_vec()),
     ]);
 
     loop {

--- a/src/client.rs
+++ b/src/client.rs
@@ -252,7 +252,7 @@ impl ClientFlow {
 
     pub fn set_authenticate_data(
         &mut self,
-        authenticate_data: AuthenticateData,
+        authenticate_data: AuthenticateData<'static>,
     ) -> Result<ClientFlowCommandHandle, AuthenticateData> {
         self.send_command_state
             .set_authenticate_data(authenticate_data)

--- a/src/send_command.rs
+++ b/src/send_command.rs
@@ -194,7 +194,7 @@ impl SendCommandState {
     /// Takes the requested authenticate data and sends it to the server.
     pub fn set_authenticate_data(
         &mut self,
-        authenticate_data: AuthenticateData,
+        authenticate_data: AuthenticateData<'static>,
     ) -> Result<ClientFlowCommandHandle, AuthenticateData> {
         // Check whether in correct state
         let Some(current_command) = self.current_command.take() else {

--- a/src/server.rs
+++ b/src/server.rs
@@ -551,7 +551,7 @@ pub enum ServerFlowEvent {
     /// Make sure to honor the client's request to not end up in an infinite loop. It's up to the
     /// server to end the authentication flow.
     AuthenticateDataReceived {
-        authenticate_data: AuthenticateData,
+        authenticate_data: AuthenticateData<'static>,
     },
     IdleCommandReceived {
         tag: Tag<'static>,

--- a/tasks/src/tasks.rs
+++ b/tasks/src/tasks.rs
@@ -114,7 +114,7 @@ impl Task for AuthenticatePlainTask {
         if self.ir {
             Ok(AuthenticateData::Cancel)
         } else if let Some(line) = self.line.take() {
-            Ok(AuthenticateData::Continue(Secret::new(line)))
+            Ok(AuthenticateData::r#continue(line))
         } else {
             Ok(AuthenticateData::Cancel)
         }


### PR DESCRIPTION
Fixes a breaking change in `imap-types`. The type `AuthenticateData` has now a lifetime parameter.
