### PR TITLE
refactor!: fix wrong usage of the term `continuation`

### DIFF
--- a/examples/client.rs
+++ b/examples/client.rs
@@ -46,8 +46,10 @@ async fn main() {
             ClientFlowEvent::StatusReceived { status } => {
                 println!("status received: {status:?}");
             }
-            ClientFlowEvent::ContinuationReceived { continuation } => {
-                println!("unexpected continuation received: {continuation:?}");
+            ClientFlowEvent::ContinuationRequestReceived {
+                continuation_request,
+            } => {
+                println!("unexpected continuation request received: {continuation_request:?}");
             }
             event => {
                 println!("{event:?}");

--- a/examples/client_authenticate.rs
+++ b/examples/client_authenticate.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         println!("{event:?}");
 
         match event {
-            ClientFlowEvent::ContinuationAuthenticateReceived { .. } => {
+            ClientFlowEvent::AuthenticateContinuationRequestReceived { .. } => {
                 if let Some(authenticate_data) = authenticate_data.pop_front() {
                     client.set_authenticate_data(authenticate_data).unwrap();
                 } else {

--- a/examples/client_idle.rs
+++ b/examples/client_idle.rs
@@ -36,8 +36,8 @@ async fn main() {
                     ClientFlowEvent::IdleCommandSent { .. } => {
                         println!("IDLE command sent")
                     },
-                    ClientFlowEvent::IdleAccepted { continuation, .. } => {
-                        println!("IDLE accepted: {continuation:?}");
+                    ClientFlowEvent::IdleAccepted { continuation_request, .. } => {
+                        println!("IDLE accepted: {continuation_request:?}");
                     },
                     ClientFlowEvent::IdleRejected { status, .. } => {
                         println!("IDLE rejected: {status:?}");

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -382,9 +382,14 @@ fn handle_server_event(
             // TODO: log handle
             trace!(role = "p2s", "---> Authentication started");
         }
-        ClientFlowEvent::ContinuationAuthenticateReceived { continuation, .. } => {
-            trace!(response=%format!("{:?}", continuation).blue(), role = "s2p", "<--| Received authentication continue");
-            client_to_proxy.authenticate_continue(continuation).unwrap();
+        ClientFlowEvent::AuthenticateContinuationRequestReceived {
+            continuation_request,
+            ..
+        } => {
+            trace!(response=%format!("{:?}", continuation_request).blue(), role = "s2p", "<--| Received authentication continuation request");
+            client_to_proxy
+                .authenticate_continue(continuation_request)
+                .unwrap();
         }
         ClientFlowEvent::AuthenticateAccepted { status, .. } => {
             trace!(response=%format!("{:?}", status).blue(), role = "s2p", "<--| Received authentication accepted");
@@ -408,10 +413,12 @@ fn handle_server_event(
             let _handle = client_to_proxy.enqueue_status(status);
             // TODO: log handle
         }
-        ClientFlowEvent::ContinuationReceived { mut continuation } => {
-            trace!(response=%format!("{:?}", continuation).blue(), role = "s2p", "<--| Received continuation");
-            util::filter_capabilities_in_continuation(&mut continuation);
-            let _handle = client_to_proxy.enqueue_continuation(continuation);
+        ClientFlowEvent::ContinuationRequestReceived {
+            mut continuation_request,
+        } => {
+            trace!(response=%format!("{:?}", continuation_request).blue(), role = "s2p", "<--| Received continuation request");
+            util::filter_capabilities_in_continuation(&mut continuation_request);
+            let _handle = client_to_proxy.enqueue_continuation_request(continuation_request);
             // TODO: log handle
         }
         ClientFlowEvent::IdleCommandSent { handle: _handle } => {
@@ -420,15 +427,15 @@ fn handle_server_event(
         }
         ClientFlowEvent::IdleAccepted {
             handle: _handle,
-            continuation,
+            continuation_request,
         } => {
             // TODO: log handle
             trace!(
                 role = "s2p",
-                ?continuation,
-                "<--| Received continuation (idle)"
+                ?continuation_request,
+                "<--| Received continuation request (idle)"
             );
-            let _handle2 = client_to_proxy.idle_accept(continuation);
+            let _handle2 = client_to_proxy.idle_accept(continuation_request);
             // TODO: log handle2
         }
         ClientFlowEvent::IdleRejected {

--- a/src/server.rs
+++ b/src/server.rs
@@ -125,14 +125,14 @@ impl ServerFlow {
     /// The response is not sent immediately but during one of the next calls of
     /// [`ServerFlow::progress`]. All responses are sent in the same order they have been
     /// enqueued.
-    pub fn enqueue_continuation(
+    pub fn enqueue_continuation_request(
         &mut self,
-        continuation: CommandContinuationRequest<'static>,
+        continuation_request: CommandContinuationRequest<'static>,
     ) -> ServerFlowResponseHandle {
         let handle = self.handle_generator.generate();
         self.send_response_state.enqueue(
             Some(handle),
-            Response::CommandContinuationRequest(continuation),
+            Response::CommandContinuationRequest(continuation_request),
         );
         handle
     }
@@ -357,13 +357,13 @@ impl ServerFlow {
 
     pub fn authenticate_continue(
         &mut self,
-        continuation: CommandContinuationRequest<'static>,
+        continuation_request: CommandContinuationRequest<'static>,
     ) -> Result<ServerFlowResponseHandle, CommandContinuationRequest<'static>> {
         if let ServerReceiveState::AuthenticateData { .. } = self.receive_command_state {
-            let handle = self.enqueue_continuation(continuation);
+            let handle = self.enqueue_continuation_request(continuation_request);
             Ok(handle)
         } else {
-            Err(continuation)
+            Err(continuation_request)
         }
     }
 
@@ -388,7 +388,7 @@ impl ServerFlow {
         continuation_request: CommandContinuationRequest<'static>,
     ) -> Result<ServerFlowResponseHandle, CommandContinuationRequest<'static>> {
         if let ServerReceiveState::IdleAccept(_) = &mut self.receive_command_state {
-            let handle = self.enqueue_continuation(continuation_request);
+            let handle = self.enqueue_continuation_request(continuation_request);
 
             self.receive_command_state
                 .change_state(NextExpectedMessage::IdleDone);

--- a/tasks/src/tasks.rs
+++ b/tasks/src/tasks.rs
@@ -107,7 +107,7 @@ impl Task for AuthenticatePlainTask {
         }
     }
 
-    fn process_continuation_authenticate(
+    fn process_continuation_request_authenticate(
         &mut self,
         _: CommandContinuationRequest<'static>,
     ) -> Result<AuthenticateData, CommandContinuationRequest<'static>> {


### PR DESCRIPTION
I'm still not happy about our names but now the semantics are right.