### PR TITLE
refactor: Implement sans I/O

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,21 +5,25 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [features]
+default = ["stream"]
 expose_stream = []
+stream = ["dep:rustls", "dep:tokio", "dep:tokio-rustls"]
 
 [dependencies]
 bounded-static = "0.5.0"
 bytes = "1.5.0"
 imap-codec = { version = "2.0.0", features = ["quirk_crlf_relaxed", "bounded-static"] }
 imap-types = { version = "2.0.0" }
+rustls = { version = "0.21.11", optional = true }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", features = ["io-util"] }
+tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net"] }
+tokio-rustls = { version = "0.24.1", optional = true }
 tracing = "0.1.40"
 
 [dev-dependencies]
 rand = "0.8.5"
 tag-generator = { path = "tag-generator" }
-tokio = { version = "1.32.0", features = ["macros", "net", "rt", "sync"] }
+tokio = { version = "1.32.0", features = ["rt", "sync"] }
 
 [workspace]
 resolver = "2"

--- a/deny.toml
+++ b/deny.toml
@@ -7,4 +7,4 @@ allow-git = [
 ]
 
 [licenses]
-allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016" ]
+allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016", "ISC" ]

--- a/deny.toml
+++ b/deny.toml
@@ -7,4 +7,11 @@ allow-git = [
 ]
 
 [licenses]
-allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016", "ISC" ]
+allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016", "ISC", "OpenSSL" ]
+
+[[licenses.clarify]]
+name = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [
+    { path = "LICENSE", hash = 0xbd0eed23 }
+]

--- a/examples/client_std.rs
+++ b/examples/client_std.rs
@@ -1,0 +1,90 @@
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+};
+
+use imap_flow::{
+    client::{ClientFlow, ClientFlowEvent, ClientFlowOptions},
+    FlowInterrupt, FlowIo,
+};
+use imap_types::{
+    command::{Command, CommandBody},
+    core::Tag,
+};
+
+fn main() {
+    let mut stream = TcpStream::connect("127.0.0.1:12345").unwrap();
+    let mut read_buffer = [0; 128];
+    let mut client = ClientFlow::new(ClientFlowOptions::default());
+
+    let greeting = loop {
+        match client.progress() {
+            Err(interrupt) => match interrupt {
+                FlowInterrupt::Io(FlowIo::NeedMoreInput) => {
+                    let count = stream.read(&mut read_buffer).unwrap();
+                    client.enqueue_input(&read_buffer[0..count]);
+                }
+                interrupt => panic!("unexpected interrupt: {interrupt:?}"),
+            },
+            Ok(event) => match event {
+                ClientFlowEvent::GreetingReceived { greeting } => break greeting,
+                event => println!("unexpected event: {event:?}"),
+            },
+        }
+    };
+
+    println!("received greeting: {greeting:?}");
+
+    let handle = client.enqueue_command(Command {
+        tag: Tag::try_from("A1").unwrap(),
+        body: CommandBody::login("Al¹cE", "pa²²w0rd").unwrap(),
+    });
+
+    loop {
+        match client.progress() {
+            Err(interrupt) => match interrupt {
+                FlowInterrupt::Io(FlowIo::NeedMoreInput) => {
+                    let count = stream.read(&mut read_buffer).unwrap();
+                    client.enqueue_input(&read_buffer[0..count]);
+                }
+                FlowInterrupt::Io(FlowIo::Output(bytes)) => {
+                    stream.write_all(&bytes).unwrap();
+                }
+                FlowInterrupt::Error(error) => {
+                    panic!("unexpected error: {error:?}");
+                }
+            },
+            Ok(event) => match event {
+                ClientFlowEvent::CommandSent {
+                    handle: got_handle,
+                    command,
+                } => {
+                    println!("command sent: {got_handle:?}, {command:?}");
+                    assert_eq!(handle, got_handle);
+                }
+                ClientFlowEvent::CommandRejected {
+                    handle: got_handle,
+                    command,
+                    status,
+                } => {
+                    println!("command rejected: {got_handle:?}, {command:?}, {status:?}");
+                    assert_eq!(handle, got_handle);
+                }
+                ClientFlowEvent::DataReceived { data } => {
+                    println!("data received: {data:?}");
+                }
+                ClientFlowEvent::StatusReceived { status } => {
+                    println!("status received: {status:?}");
+                }
+                ClientFlowEvent::ContinuationRequestReceived {
+                    continuation_request,
+                } => {
+                    println!("unexpected continuation request received: {continuation_request:?}");
+                }
+                event => {
+                    println!("{event:?}");
+                }
+            },
+        }
+    }
+}

--- a/examples/server_authenticate.rs
+++ b/examples/server_authenticate.rs
@@ -1,34 +1,32 @@
-use std::error::Error;
-
 use imap_flow::{
     server::{ServerFlow, ServerFlowEvent, ServerFlowOptions},
-    stream::AnyStream,
+    stream::Stream,
     types::CommandAuthenticate,
 };
 use imap_types::response::{CommandContinuationRequest, Greeting, Status};
 use tokio::net::TcpListener;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let (mut server, _) = {
-        let stream = {
-            let listener = TcpListener::bind("127.0.0.1:12345").await?;
-            let (stream, _) = listener.accept().await?;
-            stream
-        };
+async fn main() {
+    let listener = TcpListener::bind("127.0.0.1:12345").await.unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+    let mut stream = Stream::insecure(stream);
+    let mut server = ServerFlow::new(
+        ServerFlowOptions::default(),
+        Greeting::ok(None, "server_idle (example)").unwrap(),
+    );
 
-        ServerFlow::send_greeting(
-            AnyStream::new(stream),
-            ServerFlowOptions::default(),
-            Greeting::ok(None, "server_authenticate (example)")?,
-        )
-        .await?
-    };
+    loop {
+        match stream.progress(&mut server).await.unwrap() {
+            ServerFlowEvent::GreetingSent { .. } => break,
+            event => println!("unexpected event: {event:?}"),
+        }
+    }
 
     let mut current_authenticate_tag = None;
 
     loop {
-        let event = server.progress().await?;
+        let event = stream.progress(&mut server).await.unwrap();
         println!("{event:?}");
 
         // We don't implement any real SASL mechanism in this example.
@@ -40,36 +38,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
             } => {
                 if pretend_to_need_more_data {
                     server
-                        .authenticate_continue(CommandContinuationRequest::basic(
-                            None,
-                            "I need more data...",
-                        )?)
+                        .authenticate_continue(
+                            CommandContinuationRequest::basic(None, "I need more data...").unwrap(),
+                        )
                         .unwrap();
 
                     current_authenticate_tag = Some(tag);
                 } else {
                     server
-                        .authenticate_finish(Status::ok(
-                            Some(tag),
-                            None,
-                            "Thanks, that's already enough!",
-                        )?)
+                        .authenticate_finish(
+                            Status::ok(Some(tag), None, "Thanks, that's already enough!").unwrap(),
+                        )
                         .unwrap();
                 }
             }
             ServerFlowEvent::AuthenticateDataReceived { .. } => {
                 if pretend_to_need_more_data {
                     server
-                        .authenticate_continue(CommandContinuationRequest::basic(
-                            None,
-                            "...more...",
-                        )?)
+                        .authenticate_continue(
+                            CommandContinuationRequest::basic(None, "...more...").unwrap(),
+                        )
                         .unwrap();
                 } else {
                     let tag = current_authenticate_tag.take().unwrap();
 
                     server
-                        .authenticate_finish(Status::ok(Some(tag), None, "Thanks!")?)
+                        .authenticate_finish(Status::ok(Some(tag), None, "Thanks!").unwrap())
                         .unwrap();
                 }
             }

--- a/flow-test/src/client_tester.rs
+++ b/flow-test/src/client_tester.rs
@@ -186,16 +186,13 @@ impl ClientTester {
 #[allow(clippy::large_enum_variant)]
 enum ConnectionState {
     /// The client has established a TCP connection to the server.
-    Connected {
-        stream: Stream<ClientFlow>,
-        client: ClientFlow,
-    },
+    Connected { stream: Stream, client: ClientFlow },
     /// The TCP connection between client and server was dropped.
     Disconnected,
 }
 
 impl ConnectionState {
-    fn connected(&mut self) -> (&mut Stream<ClientFlow>, &mut ClientFlow) {
+    fn connected(&mut self) -> (&mut Stream, &mut ClientFlow) {
         match self {
             ConnectionState::Connected { stream, client } => (stream, client),
             ConnectionState::Disconnected => {

--- a/flow-test/src/runtime.rs
+++ b/flow-test/src/runtime.rs
@@ -45,9 +45,9 @@ impl Runtime {
         match self.timeout {
             None => self.rt.block_on(future),
             Some(timeout) => self.rt.block_on(async {
-                tokio::select! {
+                select! {
                     output = future => output,
-                    () = sleep(timeout) => panic!("Timeout reached"),
+                    () = sleep(timeout) => panic!("exceeded {timeout:?} timeout"),
                 }
             }),
         }

--- a/flow-test/src/server_tester.rs
+++ b/flow-test/src/server_tester.rs
@@ -1,10 +1,10 @@
 use bstr::ByteSlice;
 use imap_flow::{
     server::{ServerFlow, ServerFlowError, ServerFlowEvent, ServerFlowOptions},
-    stream::AnyStream,
+    stream::{Stream, StreamError},
 };
 use imap_types::{bounded_static::ToBoundedStatic, response::Response};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
 use tracing::trace;
 
 use crate::codecs::Codecs;
@@ -24,6 +24,7 @@ impl ServerTester {
     ) -> Self {
         let (stream, client_address) = server_listener.accept().await.unwrap();
         trace!(?client_address, "Server accepts connection");
+        let stream = Stream::insecure(stream);
         Self {
             codecs,
             server_flow_options,
@@ -34,17 +35,21 @@ impl ServerTester {
     pub async fn send_greeting(&mut self, bytes: &[u8]) {
         let enqueued_greeting = self.codecs.decode_greeting_normalized(bytes);
         match self.connection_state.take() {
-            ConnectionState::Connected { stream } => {
-                let stream = AnyStream::new(stream);
-                let (server, greeting) = ServerFlow::send_greeting(
-                    stream,
+            ConnectionState::Connected { mut stream } => {
+                let mut server = ServerFlow::new(
                     self.server_flow_options.clone(),
                     enqueued_greeting.to_static(),
-                )
-                .await
-                .unwrap();
-                assert_eq!(enqueued_greeting, greeting);
-                self.connection_state = ConnectionState::Greeted { server };
+                );
+                let event = stream.progress(&mut server).await.unwrap();
+                match event {
+                    ServerFlowEvent::GreetingSent { greeting } => {
+                        assert_eq!(enqueued_greeting, greeting);
+                    }
+                    event => {
+                        panic!("Server has unexpected event: {event:?}");
+                    }
+                }
+                self.connection_state = ConnectionState::Greeted { stream, server };
             }
             ConnectionState::Greeted { .. } => {
                 panic!("Server has already greeted");
@@ -57,8 +62,9 @@ impl ServerTester {
 
     pub async fn receive_command(&mut self, expected_bytes: &[u8]) {
         let expected_command = self.codecs.decode_command(expected_bytes);
-        let server = self.connection_state.greeted();
-        match server.progress().await.unwrap() {
+        let (stream, server) = self.connection_state.greeted();
+        let event = stream.progress(server).await.unwrap();
+        match event {
             ServerFlowEvent::CommandReceived { command } => {
                 assert_eq!(expected_command, command);
             }
@@ -70,9 +76,9 @@ impl ServerTester {
 
     pub async fn send_data(&mut self, bytes: &[u8]) {
         let enqueued_data = self.codecs.decode_data_normalized(bytes);
-        let server = self.connection_state.greeted();
+        let (stream, server) = self.connection_state.greeted();
         let enqueued_handle = server.enqueue_data(enqueued_data.to_static());
-        let event = server.progress().await.unwrap();
+        let event = stream.progress(server).await.unwrap();
         match event {
             ServerFlowEvent::ResponseSent { handle, response } => {
                 assert_eq!(enqueued_handle, handle);
@@ -86,9 +92,9 @@ impl ServerTester {
 
     pub async fn send_status(&mut self, bytes: &[u8]) {
         let enqueued_status = self.codecs.decode_status_normalized(bytes);
-        let server = self.connection_state.greeted();
+        let (stream, server) = self.connection_state.greeted();
         let enqueued_handle = server.enqueue_status(enqueued_status.to_static());
-        let event = server.progress().await.unwrap();
+        let event = stream.progress(server).await.unwrap();
         match event {
             ServerFlowEvent::ResponseSent { handle, response } => {
                 assert_eq!(enqueued_handle, handle);
@@ -100,9 +106,19 @@ impl ServerTester {
         }
     }
 
+    async fn receive_error(&mut self) -> ServerFlowError {
+        let (stream, server) = self.connection_state.greeted();
+        let error = stream.progress(server).await.unwrap_err();
+        match error {
+            StreamError::Flow(err) => err,
+            err => {
+                panic!("Server emitted unexpected error: {err:?}");
+            }
+        }
+    }
+
     pub async fn receive_error_because_expected_crlf_got_lf(&mut self, expected_bytes: &[u8]) {
-        let server = self.connection_state.greeted();
-        let error = server.progress().await.unwrap_err();
+        let error = self.receive_error().await;
         match error {
             ServerFlowError::ExpectedCrlfGotLf { discarded_bytes } => {
                 assert_eq!(
@@ -117,8 +133,7 @@ impl ServerTester {
     }
 
     pub async fn receive_error_because_malformed_message(&mut self, expected_bytes: &[u8]) {
-        let server = self.connection_state.greeted();
-        let error = server.progress().await.unwrap_err();
+        let error = self.receive_error().await;
         match error {
             ServerFlowError::MalformedMessage { discarded_bytes } => {
                 assert_eq!(
@@ -133,8 +148,7 @@ impl ServerTester {
     }
 
     pub async fn receive_error_because_literal_too_long(&mut self, expected_bytes: &[u8]) {
-        let server = self.connection_state.greeted();
-        let error = server.progress().await.unwrap_err();
+        let error = self.receive_error().await;
         match error {
             ServerFlowError::LiteralTooLong { discarded_bytes } => {
                 assert_eq!(
@@ -149,8 +163,7 @@ impl ServerTester {
     }
 
     pub async fn receive_error_because_command_too_long(&mut self, expected_bytes: &[u8]) {
-        let server = self.connection_state.greeted();
-        let error = server.progress().await.unwrap_err();
+        let error = self.receive_error().await;
         match error {
             ServerFlowError::CommandTooLong { discarded_bytes } => {
                 assert_eq!(
@@ -166,8 +179,8 @@ impl ServerTester {
 
     /// Progresses internal responses without expecting any results.
     pub async fn progress_internal_responses<T>(&mut self) -> T {
-        let server = self.connection_state.greeted();
-        let result = server.progress().await;
+        let (stream, server) = self.connection_state.greeted();
+        let result = stream.progress(server).await;
         panic!("Server has unexpected result: {result:?}");
     }
 }
@@ -176,21 +189,25 @@ impl ServerTester {
 #[allow(clippy::large_enum_variant)]
 enum ConnectionState {
     // The server has established a TCP connection to the client.
-    Connected { stream: TcpStream },
+    Connected {
+        stream: Stream<ServerFlow>,
+    },
     // The server has greeted the client.
-    Greeted { server: ServerFlow },
+    Greeted {
+        stream: Stream<ServerFlow>,
+        server: ServerFlow,
+    },
     // The TCP connection between server and client was dropped.
     Disconnected,
 }
 
 impl ConnectionState {
-    /// Assumes that the server has already greeted the client and returns the `ServerFlow`.
-    fn greeted(&mut self) -> &mut ServerFlow {
+    fn greeted(&mut self) -> (&mut Stream<ServerFlow>, &mut ServerFlow) {
         match self {
             ConnectionState::Connected { .. } => {
                 panic!("Server has not greeted yet");
             }
-            ConnectionState::Greeted { server } => server,
+            ConnectionState::Greeted { stream, server } => (stream, server),
             ConnectionState::Disconnected => {
                 panic!("Server is already disconnected");
             }

--- a/flow-test/src/server_tester.rs
+++ b/flow-test/src/server_tester.rs
@@ -189,20 +189,15 @@ impl ServerTester {
 #[allow(clippy::large_enum_variant)]
 enum ConnectionState {
     // The server has established a TCP connection to the client.
-    Connected {
-        stream: Stream<ServerFlow>,
-    },
+    Connected { stream: Stream },
     // The server has greeted the client.
-    Greeted {
-        stream: Stream<ServerFlow>,
-        server: ServerFlow,
-    },
+    Greeted { stream: Stream, server: ServerFlow },
     // The TCP connection between server and client was dropped.
     Disconnected,
 }
 
 impl ConnectionState {
-    fn greeted(&mut self) -> (&mut Stream<ServerFlow>, &mut ServerFlow) {
+    fn greeted(&mut self) -> (&mut Stream, &mut ServerFlow) {
         match self {
             ConnectionState::Connected { .. } => {
                 panic!("Server has not greeted yet");

--- a/flow-test/tests/flow-test-server.rs
+++ b/flow-test/tests/flow-test-server.rs
@@ -164,6 +164,8 @@ fn command_larger_than_max_command_size() {
     for max_command_size in max_command_size_tests {
         let mut setup = TestSetup::default();
         setup.server_flow_options.max_command_size = max_command_size as u32;
+        // Sending large messages takes some time, especially when running on a slow CI.
+        setup.runtime_options.timeout = Some(Duration::from_secs(10));
 
         let (rt, mut server, mut client) = setup.setup_server();
 

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -116,7 +116,7 @@ impl Proxy<BoundState> {
 
 pub struct ClientAcceptedState {
     client_addr: SocketAddr,
-    client_to_proxy: Stream<ServerFlow>,
+    client_to_proxy: Stream,
 }
 
 impl State for ClientAcceptedState {}
@@ -183,8 +183,8 @@ impl Proxy<ClientAcceptedState> {
 }
 
 pub struct ConnectedState {
-    client_to_proxy: Stream<ServerFlow>,
-    proxy_to_server: Stream<ClientFlow>,
+    client_to_proxy: Stream,
+    proxy_to_server: Stream,
 }
 
 impl State for ConnectedState {}

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -365,8 +365,8 @@ fn handle_server_event(
 
     match event {
         ClientFlowEvent::GreetingReceived { greeting } => {
-            // This event will only emitted at the beginning and we already handled it
-            // somewhere else
+            // This event is emitted only at the beginning so we must have already
+            // handled it somewhere else.
             error!(role = "s2p", ?greeting, "Unexpected greeting");
         }
         ClientFlowEvent::CommandSent { handle, .. } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub trait Flow {
 /// The IMAP flow was interrupted by an event that needs to be handled externally.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FlowInterrupt<E> {
-    /// An IO operation is necessary. Ignoring this might result in a dead lock on IMAP level.
+    /// An IO operation is necessary. Ignoring this might result in a deadlock on IMAP level.
     Io(FlowIo),
     /// An error occurred. Ignoring this might result in an undefined IMAP state.
     Error(E),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,15 +12,23 @@ pub mod stream;
 mod tests;
 pub mod types;
 
-/// Simple abstraction of IMAP flows that can be used for implementing IO utilities.
+/// Common sans I/O interface used to implement I/O drivers for types that implement our protocol flows.
 ///
-/// The utility [`Stream`](stream::Stream) is using this for implementing the IO bits when
-/// dealing with TCP or TLS.
+/// Most notably, [`ClientFlow`](client::ClientFlow) and [`ServerFlow`](server::ServerFlow) both implement
+/// this trait whereas [`Stream`](stream::Stream) implements the I/O drivers.
 pub trait Flow {
+    /// Event emitted while progressing the protocol flow.
     type Event;
+
+    /// Error emitted while progressing the protocol flow.
     type Error;
 
+    /// Enqueue input bytes.
+    ///
+    /// These bytes may be used during the next [`Self::progress`] call.
     fn enqueue_input(&mut self, bytes: &[u8]);
+
+    /// Progress the protocol flow until the next event (or interrupt).
     fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>>;
 }
 
@@ -37,8 +45,8 @@ impl<F: Flow> Flow for &mut F {
     }
 }
 
-/// The IMAP flow was interrupted by an event that needs to be handled externally.
-#[must_use = "If the IMAP flow is interrupted the interrupt must be handled. Ignoring this might result in a deadlock on IMAP level"]
+/// The protocol flow was interrupted by an event that needs to be handled externally.
+#[must_use = "If the protocol flow is interrupted the interrupt must be handled. Ignoring this might result in a deadlock on IMAP level"]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FlowInterrupt<E> {
     /// An IO operation is necessary. Ignoring this might result in a deadlock on IMAP level.
@@ -47,7 +55,7 @@ pub enum FlowInterrupt<E> {
     Error(E),
 }
 
-/// The user of `imap-flow` must perform an IO operation in order to progress the IMAP flow.
+/// The user of `imap-flow` must perform an IO operation in order to progress the protocol flow.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FlowIo {
     /// More bytes must be read and passed to [`Flow::enqueue_input`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,43 @@
 #![forbid(unsafe_code)]
+
 pub mod client;
 mod handle;
 mod receive;
 mod send_command;
 mod send_response;
 pub mod server;
+#[cfg(feature = "stream")]
 pub mod stream;
-pub mod types;
-
 #[cfg(test)]
 mod tests;
+pub mod types;
+
+/// Simple abstraction of IMAP flows that can be used for implementing IO utilities.
+///
+/// The utility [`Stream`](stream::Stream) is using this for implementing the IO bits when
+/// dealing with TCP or TLS.
+pub trait Flow {
+    type Event;
+    type Error;
+
+    fn enqueue_input(&mut self, bytes: &[u8]);
+    fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>>;
+}
+
+/// The IMAP flow was interrupted by an event that needs to be handled externally.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FlowInterrupt<E> {
+    /// An IO operation is necessary. Ignoring this might result in a dead lock on IMAP level.
+    Io(FlowIo),
+    /// An error occurred. Ignoring this might result in an undefined IMAP state.
+    Error(E),
+}
+
+/// The user of `imap-flow` must perform an IO operation in order to progress the IMAP flow.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FlowIo {
+    /// More bytes must be read and passed to [`Flow::enqueue_input`].
+    NeedMoreInput,
+    /// The given bytes must be written.
+    Output(Vec<u8>),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,19 @@ pub trait Flow {
     fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>>;
 }
 
+impl<F: Flow> Flow for &mut F {
+    type Event = F::Event;
+    type Error = F::Error;
+
+    fn enqueue_input(&mut self, bytes: &[u8]) {
+        (*self).enqueue_input(bytes);
+    }
+
+    fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>> {
+        (*self).progress()
+    }
+}
+
 /// The IMAP flow was interrupted by an event that needs to be handled externally.
 #[must_use = "If the IMAP flow is interrupted the interrupt must be handled. Ignoring this might result in a deadlock on IMAP level"]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub trait Flow {
 }
 
 /// The IMAP flow was interrupted by an event that needs to be handled externally.
+#[must_use = "If the IMAP flow is interrupted the interrupt must be handled. Ignoring this might result in a deadlock on IMAP level"]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FlowInterrupt<E> {
     /// An IO operation is necessary. Ignoring this might result in a deadlock on IMAP level.

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -66,18 +66,16 @@ impl<C> ReceiveState<C> {
         for<'a> C::Message<'a>: IntoBoundedStatic<Static = C::Message<'static>>,
         for<'a> C::Error<'a>: IntoBoundedStatic<Static = C::Error<'static>>,
     {
-        let event = loop {
+        loop {
             match self.next_fragment {
                 NextFragment::Line { seen_bytes_in_line } => {
-                    break self.progress_line(seen_bytes_in_line)?;
+                    break Ok(self.progress_line(seen_bytes_in_line)?);
                 }
                 NextFragment::Literal { length } => {
                     self.progress_literal(length)?;
                 }
             };
-        };
-
-        Ok(event)
+        }
     }
 
     fn progress_line(

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -9,12 +9,12 @@ pub struct ReceiveState<C> {
     crlf_relaxed: bool,
     max_message_size: Option<u32>,
     next_fragment: NextFragment,
-    // How many bytes in the parse buffer do we already have checked?
-    // This is important if we need multiple attempts to read from the underlying
-    // stream before the message is completely received.
+    /// How many bytes in the parse buffer do we already have checked?
+    /// This is important if we need multiple attempts to read from the underlying
+    /// stream before the message is completely received.
     seen_bytes: usize,
-    // Used for reading the current message from the stream.
-    // Its length should always be equal to or greater than `seen_bytes`.
+    /// Used for reading the current message from the stream.
+    /// Its length should always be equal to or greater than `seen_bytes`.
     read_buffer: BytesMut,
 }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -160,8 +160,8 @@ impl<F: Flow> Stream<F> {
             if self.write_buffer.is_empty() {
                 read(&mut self.stream, &mut self.read_buffer).await?;
             } else {
-                // We read and write the stream simultanously because otherwise a
-                // a dead lock between client and server might occur if both sides
+                // We read and write the stream simultaneously because otherwise a
+                // a deadlock between client and server might occur if both sides
                 // would only read or only write.
                 let (read_stream, write_stream) = self.stream.split();
                 select! {
@@ -181,7 +181,7 @@ pub enum StreamError<E> {
     /// The operation failed because the stream is closed.
     ///
     /// We detect this by checking if the read or written byte count is 0. Whether the stream is
-    /// closed indefinitely or temporarily depend on the actual stream implementation.
+    /// closed indefinitely or temporarily depends on the actual stream implementation.
     #[error("Stream was closed")]
     Closed,
     /// An I/O error occurred in the underlying stream.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -40,7 +40,7 @@ impl<F> Stream<F> {
 
     pub fn tls(stream: TlsStream<TcpStream>) -> Self {
         // We want to use `TcpStream::split` for handling reading and writing separately,
-        // but `TlsStream` does not expose this functionality. Therefore we destruct `TlsStream`
+        // but `TlsStream` does not expose this functionality. Therefore, we destruct `TlsStream`
         // into `TcpStream` and `rustls::Connection` and handling them ourselves.
         //
         // Some notes:
@@ -50,7 +50,7 @@ impl<F> Stream<F> {
         //   different threads. We prefer to use the more low-level `TcpStream::split`.
         //
         // - We could get rid of `TlsStream` and construct `rustls::Connection` directly.
-        //   But `TlsStream` is still useful because it give us the guarantee that the handshake
+        //   But `TlsStream` is still useful because it gives us the guarantee that the handshake
         //   was already handled properly.
         //
         // - In the long run it would be nice if `TlsStream::split` would exist and we would use
@@ -160,7 +160,7 @@ impl<F: Flow> Stream<F> {
             if self.write_buffer.is_empty() {
                 read(&mut self.stream, &mut self.read_buffer).await?;
             } else {
-                // We read and write the stream simultaneously because otherwise a
+                // We read and write the stream simultaneously because otherwise
                 // a deadlock between client and server might occur if both sides
                 // would only read or only write.
                 let (read_stream, write_stream) = self.stream.split();


### PR DESCRIPTION
These types are now sans I/O:

- `imap_flow::client::ClientFlow`
- `imap_flow::server::ServerFlow`
- `imap_tasks::Scheduler`

All of them implement the new trait `imap_flow::Flow` which provides just enough interface for implementing I/O utilities. 

For interacting with I/O there is now the optional utility `imap_flow::stream::Stream` based on `tokio` and `tokio_rustls`. This utility and its dependencies can be enabled/disabled with the feature flag `stream` which is enabled by default.

The current usage looks like this:

```rust
let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
let mut stream = Stream::insecure(stream);
let mut client = ClientFlow::new(ClientFlowOptions::default());

let greeting = loop {
    match stream.progress(&mut client).await.unwrap() {
        ClientFlowEvent::GreetingReceived { greeting } => break greeting,
        event => println!("unexpected event: {event:?}"),
    }
};
```

This PR is only the first (big) step. I think there are a lot of smaller API changes and follow-up refactorings that we can and should do. But for now let's focus on the rough design.

Closes #154
Closes #37 
Closes #134
Relates to #98 