### PR TITLE
Fix rustdoc::broken_intra_doc_links

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -340,7 +340,7 @@ pub enum ClientFlowEvent {
     },
     /// Server is requesting (more) authentication data.
     ///
-    /// The client MUST call [`ClientFlow::authenticate_continue`] next.
+    /// The client MUST call [`SendCommandState::authenticate_continue`] next.
     ///
     /// Note: The client can also progress the authentication by sending [`AuthenticateData::Cancel`].
     /// However, it's up to the server to abort the authentication flow by sending a tagged status response.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 pub mod client;
 mod handle;
 mod receive;
-mod send_command;
+pub mod send_command;
 mod send_response;
 pub mod server;
 pub mod stream;

--- a/src/send_command.rs
+++ b/src/send_command.rs
@@ -614,7 +614,7 @@ enum AuthenticateActivity {
     WaitingForAuthenticateResponse,
     /// Waiting until the client flow user provides the authenticate data.
     ///
-    /// Specifically, [`ClientFlow::set_authenticate_data`].
+    /// Specifically, [`SendCommandState::set_authenticate_data`].
     WaitingForAuthenticateDataSet,
     /// Pushing the authenticate data to the write buffer.
     PushingAuthenticateData { authenticate_data: Vec<u8> },
@@ -679,7 +679,7 @@ enum IdleActivity {
     WaitingForIdleResponse,
     /// Waiting until the client flow user triggers idle done.
     ///
-    /// Specifically, [`ClientFlow::set_idle_done`].
+    /// Specifically, [`SendCommandState::set_idle_done`].
     WaitingForIdleDoneSet,
     /// Pushing the idle done to the write buffer.
     PushingIdleDone { idle_done: Vec<u8> },


### PR DESCRIPTION
Fix warnings that show up when running `cargo doc [..]` which reports warnings like:

```
  warning: unresolved link to `ClientFlow::set_idle_done`
     --> src/send_command.rs:682:25
      |
  682 |     /// Specifically, [`ClientFlow::set_idle_done`].
      |                         ^^^^^^^^^^^^^^^^^^^^^^^^^ no item named `ClientFlow` in scope
      |
      = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```