### PR TITLE
Task runner (mid-level API), part 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ stream = ["dep:rustls", "dep:tokio", "dep:tokio-rustls"]
 [dependencies]
 bounded-static = "0.5.0"
 bytes = "1.5.0"
-imap-codec = { version = "2.0.0", features = ["quirk_crlf_relaxed", "bounded-static"] }
-imap-types = { version = "2.0.0" }
+imap-codec = { version = "2.0.0", features = ["quirk_crlf_relaxed", "bounded-static", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
+imap-types = { version = "2.0.0", features = ["ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
 rustls = { version = "0.23.1", optional = true }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net"] }
+tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net", "sync", "time"] }
 tokio-rustls = { version = "0.26.0", optional = true }
 tracing = "0.1.40"
 
 [dev-dependencies]
 rand = "0.8.5"
 tag-generator = { path = "tag-generator" }
-tokio = { version = "1.32.0", features = ["rt", "sync"] }
+tokio = { version = "1.32.0", features = ["full"] }
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ stream = ["dep:rustls", "dep:tokio", "dep:tokio-rustls"]
 [dependencies]
 bounded-static = "0.5.0"
 bytes = "1.5.0"
-imap-codec = { version = "2.0.0", features = ["quirk_crlf_relaxed", "bounded-static", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
-imap-types = { version = "2.0.0", features = ["ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
+imap-codec = { version = "2.0.0", features = ["starttls", "quirk_crlf_relaxed", "bounded-static", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
+imap-types = { version = "2.0.0", features = ["starttls", "ext_condstore_qresync", "ext_login_referrals", "ext_mailbox_referrals", "ext_id", "ext_sort_thread", "ext_binary", "ext_metadata", "ext_uidplus"] }
 rustls = { version = "0.23.1", optional = true }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net", "sync", "time"] }
+tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net"] }
 tokio-rustls = { version = "0.26.0", optional = true }
 tracing = "0.1.40"
 
 [dev-dependencies]
 rand = "0.8.5"
 tag-generator = { path = "tag-generator" }
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] }
 
 [workspace]
 resolver = "2"

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 imap-flow = { path = ".." }
 imap-types = "2.0.0"
+static_assertions = "1.1.0"
 tag-generator = { path = "../tag-generator" }
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["net"] }

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[dev-dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
-
 [dependencies]
 imap-flow = { path = ".." }
 imap-types = "2.0.0"
 tag-generator = { path = "../tag-generator" }
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["net"] }
+
+[dev-dependencies]
+tokio = { version = "1.37.0", features = ["full"] }

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -7,10 +7,10 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 imap-flow = { path = ".." }
 imap-types = "2.0.0"
-static_assertions = "1.1.0"
 tag-generator = { path = "../tag-generator" }
 thiserror = "1.0.58"
-tokio = { version = "1.37.0", features = ["net"] }
+tracing = "0.1.40"
 
 [dev-dependencies]
+static_assertions = "1.1.0"
 tokio = { version = "1.37.0", features = ["full"] }

--- a/tasks/Cargo.toml
+++ b/tasks/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[dev-dependencies]
+tokio = { version = "1.32.0", features = ["full"] }
+
 [dependencies]
 imap-flow = { path = ".." }
 imap-types = "2.0.0"
 tag-generator = { path = "../tag-generator" }
 thiserror = "1.0.58"
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.37.0", features = ["net"] }

--- a/tasks/examples/client-resolver.rs
+++ b/tasks/examples/client-resolver.rs
@@ -1,0 +1,47 @@
+use imap_flow::{
+    client::{ClientFlow, ClientFlowOptions},
+    stream::Stream,
+};
+use tasks::{
+    resolver::Resolver,
+    tasks::{authenticate::AuthenticateTask, capability::CapabilityTask, logout::LogoutTask},
+};
+use tokio::net::TcpStream;
+
+#[tokio::main]
+async fn main() {
+    let stream = TcpStream::connect("127.0.0.1:12345").await.unwrap();
+    let mut stream = Stream::insecure(stream);
+    let client = ClientFlow::new(ClientFlowOptions::default());
+    let mut resolver = Resolver::new(client);
+
+    let capability = stream
+        .progress(resolver.run_task(CapabilityTask::new()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    println!("pre-auth capability: {capability:?}");
+
+    let capability = stream
+        .progress(resolver.run_task(AuthenticateTask::plain("alice", "pa²²w0rd", true)))
+        .await
+        .unwrap()
+        .unwrap();
+
+    println!("maybe post-auth capability: {capability:?}");
+
+    let capability = stream
+        .progress(resolver.run_task(CapabilityTask::new()))
+        .await
+        .unwrap()
+        .unwrap();
+
+    println!("post-auth capability: {capability:?}");
+
+    stream
+        .progress(resolver.run_task(LogoutTask::default()))
+        .await
+        .unwrap()
+        .unwrap();
+}

--- a/tasks/examples/client-resolver.rs
+++ b/tasks/examples/client-resolver.rs
@@ -16,7 +16,7 @@ async fn main() {
     let mut resolver = Resolver::new(client);
 
     let capability = stream
-        .progress(resolver.run_task(CapabilityTask::new()))
+        .progress(resolver.resolve(CapabilityTask::new()))
         .await
         .unwrap()
         .unwrap();
@@ -24,7 +24,7 @@ async fn main() {
     println!("pre-auth capability: {capability:?}");
 
     let capability = stream
-        .progress(resolver.run_task(AuthenticateTask::plain("alice", "pa²²w0rd", true)))
+        .progress(resolver.resolve(AuthenticateTask::plain("alice", "pa²²w0rd", true)))
         .await
         .unwrap()
         .unwrap();
@@ -32,7 +32,7 @@ async fn main() {
     println!("maybe post-auth capability: {capability:?}");
 
     let capability = stream
-        .progress(resolver.run_task(CapabilityTask::new()))
+        .progress(resolver.resolve(CapabilityTask::new()))
         .await
         .unwrap()
         .unwrap();
@@ -40,7 +40,7 @@ async fn main() {
     println!("post-auth capability: {capability:?}");
 
     stream
-        .progress(resolver.run_task(LogoutTask::default()))
+        .progress(resolver.resolve(LogoutTask::default()))
         .await
         .unwrap()
         .unwrap();

--- a/tasks/examples/client-tasks.rs
+++ b/tasks/examples/client-tasks.rs
@@ -25,7 +25,7 @@ async fn main() {
     println!("capabilities: {capabilities:#?}");
 
     let handle2 = scheduler.enqueue_task(AuthenticateTask::plain("alice", "pa²²w0rd", true));
-    let handle3 = scheduler.enqueue_task(LogoutTask::new());
+    let handle3 = scheduler.enqueue_task(LogoutTask::default());
 
     loop {
         match stream.progress(&mut scheduler).await.unwrap() {

--- a/tasks/examples/client-tasks.rs
+++ b/tasks/examples/client-tasks.rs
@@ -4,7 +4,7 @@ use imap_flow::{
 };
 use imap_types::response::{Response, Status};
 use tasks::{
-    tasks::{authenticate::AuthenticateTask, logout::LogoutTask},
+    tasks::{authenticate::AuthenticateTask, capability::CapabilityTask, logout::LogoutTask},
     Scheduler, SchedulerEvent,
 };
 use tokio::net::TcpStream;
@@ -17,11 +17,10 @@ async fn main() {
     let mut scheduler = Scheduler::new(client);
 
     let capabilities = stream
-        .progress(scheduler.capability())
+        .progress(scheduler.run_task(CapabilityTask::new()))
         .await
         .unwrap()
         .unwrap();
-
     println!("capabilities: {capabilities:#?}");
 
     let handle2 = scheduler.enqueue_task(AuthenticateTask::plain("alice", "pa²²w0rd", true));

--- a/tasks/examples/client-tasks.rs
+++ b/tasks/examples/client-tasks.rs
@@ -21,20 +21,21 @@ async fn main() {
         .await
         .unwrap()
         .unwrap();
-    println!("capabilities: {capabilities:#?}");
 
-    let handle2 = scheduler.enqueue_task(AuthenticateTask::plain("alice", "pa²²w0rd", true));
-    let handle3 = scheduler.enqueue_task(LogoutTask::default());
+    println!("capabilities: {capabilities:?}");
+
+    let auth_handle = scheduler.enqueue_task(AuthenticateTask::plain("alice", "pa²²w0rd", true));
+    let logout_handle = scheduler.enqueue_task(LogoutTask::default());
 
     loop {
         match stream.progress(&mut scheduler).await.unwrap() {
             SchedulerEvent::TaskFinished(mut token) => {
-                if let Some(auth) = handle2.resolve(&mut token) {
-                    println!("handle2: {auth:?}");
+                if let Some(auth) = auth_handle.resolve(&mut token) {
+                    println!("auth: {auth:?}");
                 }
 
-                if let Some(logout) = handle3.resolve(&mut token) {
-                    println!("handle3: {logout:?}");
+                if let Some(logout) = logout_handle.resolve(&mut token) {
+                    println!("logout: {logout:?}");
                     break;
                 }
             }

--- a/tasks/src/lib.rs
+++ b/tasks/src/lib.rs
@@ -19,9 +19,6 @@ use imap_types::{
 };
 use static_assertions::assert_impl_all;
 use tag_generator::TagGenerator;
-use tasks::{
-    authenticate::AuthenticateTask, capability::CapabilityTask, logout::LogoutTask, noop::NoOpTask,
-};
 use thiserror::Error;
 
 /// Tells how a specific IMAP [`Command`] is processed.
@@ -150,30 +147,6 @@ impl Scheduler {
             scheduler: self,
             handle,
         }
-    }
-
-    /// Run the [`CapabilityTask`].
-    pub fn capability(&mut self) -> TaskRunner<CapabilityTask> {
-        self.run_task(CapabilityTask::new())
-    }
-
-    /// Run the [`AuthenticateTask`], using the `PLAIN` auth mechanism.
-    pub fn authenticate_plain(
-        &mut self,
-        login: &str,
-        passwd: &str,
-    ) -> TaskRunner<AuthenticateTask> {
-        self.run_task(AuthenticateTask::plain(login, passwd, true))
-    }
-
-    /// Run the [`LogoutTask`].
-    pub fn logout(&mut self) -> TaskRunner<LogoutTask> {
-        self.run_task(LogoutTask::new())
-    }
-
-    /// Run the [`NoOpTask`].
-    pub fn noop(&mut self) -> TaskRunner<NoOpTask> {
-        self.run_task(NoOpTask::new())
     }
 
     pub fn enqueue_input(&mut self, bytes: &[u8]) {
@@ -373,7 +346,6 @@ pub enum SchedulerError {
     /// Flow error.
     #[error("flow error")]
     Flow(#[from] ClientFlowError),
-
     /// Unexpected tag in command completion result.
     ///
     /// The scheduler received a tag that cannot be matched to an active command.
@@ -383,7 +355,6 @@ pub enum SchedulerError {
     /// It's better to halt the execution to avoid damage.
     #[error("unexpected tag in command completion result")]
     UnexpectedTaggedResponse(Tagged<'static>),
-
     #[error("unexpected BYE response")]
     UnexpectedByeResponse(Bye<'static>),
 }

--- a/tasks/src/lib.rs
+++ b/tasks/src/lib.rs
@@ -140,7 +140,7 @@ impl Scheduler {
     }
 
     /// Enqueue a [`Task`] for immediate resolution.
-    pub fn run_task<'a, T: Task>(&'a mut self, task: T) -> TaskRunner<'a, T> {
+    pub fn run_task<T: Task>(&mut self, task: T) -> TaskRunner<T> {
         let handle = self.enqueue_task(task);
 
         TaskRunner {

--- a/tasks/src/resolver.rs
+++ b/tasks/src/resolver.rs
@@ -1,0 +1,87 @@
+use imap_flow::{client::ClientFlow, Flow, FlowInterrupt};
+use imap_types::response::{Response, Status};
+use tracing::warn;
+
+use crate::{Scheduler, SchedulerError, SchedulerEvent, Task, TaskHandle};
+
+/// The resolver is a scheduler than manages one task at a time.
+pub struct Resolver {
+    scheduler: Scheduler,
+}
+
+impl Flow for Resolver {
+    type Event = SchedulerEvent;
+    type Error = SchedulerError;
+
+    fn enqueue_input(&mut self, bytes: &[u8]) {
+        self.scheduler.enqueue_input(bytes);
+    }
+
+    fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>> {
+        self.scheduler.progress()
+    }
+}
+
+impl Resolver {
+    /// Create a new resolver.
+    pub fn new(flow: ClientFlow) -> Self {
+        Self {
+            scheduler: Scheduler::new(flow),
+        }
+    }
+
+    /// Enqueue a [`Task`] for immediate resolution.
+    pub fn run_task<T: Task>(&mut self, task: T) -> TaskResolver<T> {
+        let handle = self.scheduler.enqueue_task(task);
+
+        TaskResolver {
+            resolver: self,
+            handle,
+        }
+    }
+}
+
+pub struct TaskResolver<'a, T: Task> {
+    resolver: &'a mut Resolver,
+    handle: TaskHandle<T>,
+}
+
+impl<T: Task> Flow for TaskResolver<'_, T> {
+    type Event = T::Output;
+    type Error = SchedulerError;
+
+    fn enqueue_input(&mut self, bytes: &[u8]) {
+        self.resolver.enqueue_input(bytes);
+    }
+
+    fn progress(&mut self) -> Result<Self::Event, FlowInterrupt<Self::Error>> {
+        loop {
+            match self.resolver.progress()? {
+                SchedulerEvent::TaskFinished(mut token) => {
+                    if let Some(output) = self.handle.resolve(&mut token) {
+                        break Ok(output);
+                    } else {
+                        warn!("received unexpected task token: {token:?}")
+                    }
+                }
+                SchedulerEvent::Unsolicited(unsolicited) => {
+                    if let Response::Status(Status::Bye(bye)) = unsolicited {
+                        let err = SchedulerError::UnexpectedByeResponse(bye);
+                        break Err(FlowInterrupt::Error(err));
+                    } else {
+                        warn!("received unsolicited: {unsolicited:?}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use static_assertions::assert_impl_all;
+
+    use super::Resolver;
+
+    assert_impl_all!(Resolver: Send);
+}


### PR DESCRIPTION
Split version of #165, part 1.

- Added core changes
- Added the new `Resolver` flow that aims to enqueue task AND get resolution straight. `Resolver::run_task` returns a new `Flow` called `TaskResolver` that can feed `Stream::progress`.
- Made sure `Scheduler` and `Resolver` are `Send`.