### PR TITLE
Upgrade `rustls` and `tokio-rustls`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -45,6 +45,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup | Install NASM (Windows)
+        uses: ilammy/setup-nasm@v1
+        if: matrix.os == 'windows-latest'
+
       - name: Setup | Install toolchain
         run: |
           rustup update --no-self-update stable

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Setup | Install toolchain
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup toolchain install nightly --profile minimal
+          rustup update --no-self-update stable
+          rustup update --no-self-update nightly
+          rustup set profile minimal
 
       - name: Setup | Install cargo-fuzz
         run: |
@@ -101,8 +102,9 @@ jobs:
       - name: Setup | Install toolchain
         run: |
           # 1.66 is the Minimum Supported Rust Version (MSRV) for imap-flow.
-          rustup toolchain install 1.66 --profile minimal
-          rustup toolchain install nightly --profile minimal
+          rustup update --no-self-update 1.66
+          rustup update --no-self-update nightly
+          rustup set profile minimal
 
       - name: Setup | Cache dependencies
         uses: Swatinem/rust-cache@v2.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ bounded-static = "0.5.0"
 bytes = "1.5.0"
 imap-codec = { version = "2.0.0", features = ["quirk_crlf_relaxed", "bounded-static"] }
 imap-types = { version = "2.0.0" }
-rustls = { version = "0.21.11", optional = true }
+rustls = { version = "0.23.1", optional = true }
 thiserror = "1.0.49"
 tokio = { version = "1.32.0", optional = true, features = ["io-util", "macros", "net"] }
-tokio-rustls = { version = "0.24.1", optional = true }
+tokio-rustls = { version = "0.26.0", optional = true }
 tracing = "0.1.40"
 
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -7,7 +7,7 @@ allow-git = [
 ]
 
 [licenses]
-allow = [ "Apache-2.0", "MIT", "Unicode-DFS-2016", "ISC", "OpenSSL" ]
+allow = [ "Apache-2.0", "BSD-3-Clause", "MIT", "Unicode-DFS-2016", "ISC", "OpenSSL" ]
 
 [[licenses.clarify]]
 name = "ring"

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -11,13 +11,13 @@ colored = "2.0.4"
 imap-codec = { version = "2.0.0", features = ["bounded-static", "quirk_crlf_relaxed", "ext_id"] }
 imap-flow = { path = ".." }
 imap-types = { version = "2.0.0", features = ["bounded-static", "ext_id"] }
-rustls = "0.21.7"
+once_cell = "1.19.0"
+rustls-native-certs = "0.7.0"
 rustls-pemfile = "2.0.0-alpha.1"
 serde = { version = "1.0.171", features = ["derive"] }
 thiserror = "1.0.49"
 tokio = { version = "1.28", features = ["full"] }
-tokio-rustls = "0.24.1"
+tokio-rustls = "0.26.0"
 toml = "0.8.2"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-webpki-roots = "0.25.2"


### PR DESCRIPTION
I bumped `rustls@0.23.1` and `tokio-rustls@0.26.0`.

I also replaced `webpki-roots` by `rustls-native-certs` (see [why](https://github.com/rustls/rustls-native-certs?tab=readme-ov-file#should-i-use-this-or-webpki-roots)), and put native certs loading in a static [`Lazy`](https://crates.io/crates/once_cell) cell.

---

What is the prefered method to test examples (the server `127.0.0.1:12345`)?