### PR TITLE
Implement `Stream` to `TcpStream` conversion

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -172,6 +172,16 @@ impl Stream {
     }
 }
 
+/// Take the [`TcpStream`] out of a [`Stream`].
+///
+/// Useful when a TCP stream needs to be upgraded to a TLS one.
+#[cfg(feature = "expose_stream")]
+impl From<Stream> for TcpStream {
+    fn from(stream: Stream) -> Self {
+        stream.stream
+    }
+}
+
 /// Error during reading into or writing from a stream.
 #[derive(Debug, Error)]
 pub enum StreamError<E> {


### PR DESCRIPTION
Mostly needed for STARTTLS, see usage at https://github.com/duesee/imap-flow/pull/174/files#diff-3f7e738903cc8204a4e3b1c8ab4db5812898e6bb5ad8b6c7b36df42e29481a8fR197