### PR TITLE
fix!: Check CCR creation early to avoid panic (or late error handling)

### DIFF
--- a/flow-test/tests/flow-test-server.rs
+++ b/flow-test/tests/flow-test-server.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use flow_test::test_setup::TestSetup;
-use imap_types::core::Text;
 
 #[test]
 fn noop() {
@@ -104,7 +103,10 @@ fn login_with_literal() {
 
     for max_literal_size in max_literal_size_tests {
         let mut setup = TestSetup::default();
-        setup.server_flow_options.literal_accept_text = Text::unvalidated("You shall pass");
+        setup
+            .server_flow_options
+            .set_literal_accept_text("You shall pass".to_string())
+            .unwrap();
         setup.server_flow_options.max_literal_size = max_literal_size;
 
         let (rt, mut server, mut client) = setup.setup_server();
@@ -137,7 +139,10 @@ fn login_with_rejected_literal() {
 
     for max_literal_size in max_literal_size_tests {
         let mut setup = TestSetup::default();
-        setup.server_flow_options.literal_reject_text = Text::unvalidated("You shall not pass");
+        setup
+            .server_flow_options
+            .set_literal_reject_text("You shall not pass".to_owned())
+            .unwrap();
         setup.server_flow_options.max_literal_size = max_literal_size;
 
         let (rt, mut server, mut client) = setup.setup_server();
@@ -199,7 +204,10 @@ fn command_with_literals_larger_than_max_command_size() {
         let max_command_size = 28;
 
         let mut setup = TestSetup::default();
-        setup.server_flow_options.literal_accept_text = Text::unvalidated("more data");
+        setup
+            .server_flow_options
+            .set_literal_accept_text("more data".to_owned())
+            .unwrap();
         // Max literal size must be smaller than max command size
         setup.server_flow_options.max_literal_size = password_size as u32;
         setup.server_flow_options.max_command_size = max_command_size as u32;

--- a/flow-test/tests/flow-test.rs
+++ b/flow-test/tests/flow-test.rs
@@ -1,5 +1,4 @@
 use flow_test::test_setup::TestSetup;
-use imap_types::core::Text;
 
 #[test]
 fn noop() {
@@ -25,7 +24,10 @@ fn login_with_literal() {
 
     for max_literal_size in max_literal_size_tests {
         let mut setup = TestSetup::default();
-        setup.server_flow_options.literal_accept_text = Text::unvalidated("You shall pass");
+        setup
+            .server_flow_options
+            .set_literal_accept_text("You shall pass".to_owned())
+            .unwrap();
         setup.server_flow_options.max_literal_size = max_literal_size;
 
         let (rt, mut server, mut client) = TestSetup::default().setup();
@@ -51,7 +53,10 @@ fn login_with_rejected_literal() {
 
     for max_literal_size in max_literal_size_tests {
         let mut setup = TestSetup::default();
-        setup.server_flow_options.literal_reject_text = Text::unvalidated("You shall not pass");
+        setup
+            .server_flow_options
+            .set_literal_reject_text("You shall not pass".to_owned())
+            .unwrap();
         setup.server_flow_options.max_literal_size = max_literal_size;
 
         let (rt, mut server, mut client) = setup.setup();

--- a/proxy/src/proxy.rs
+++ b/proxy/src/proxy.rs
@@ -9,7 +9,6 @@ use imap_flow::{
 use imap_types::{
     bounded_static::ToBoundedStatic,
     command::{Command, CommandBody},
-    core::Text,
     extensions::idle::IdleDone,
     response::{Code, Status},
 };
@@ -213,8 +212,12 @@ impl Proxy<ConnectedState> {
         let mut client_to_proxy_flow = {
             // TODO(#144): Read options from config
             let mut options = ServerFlowOptions::default();
-            options.literal_accept_text = Text::try_from(LITERAL_ACCEPT_TEXT).unwrap();
-            options.literal_reject_text = Text::try_from(LITERAL_REJECT_TEXT).unwrap();
+            options
+                .set_literal_accept_text(LITERAL_ACCEPT_TEXT.to_string())
+                .unwrap();
+            options
+                .set_literal_reject_text(LITERAL_REJECT_TEXT.to_string())
+                .unwrap();
             ServerFlow::new(options, greeting)
         };
         let mut client_to_proxy_stream = self.state.client_to_proxy;


### PR DESCRIPTION
First attempt. We could make it work with `&'static str` and `String`... Closes #170.